### PR TITLE
Azure Functions support

### DIFF
--- a/azurefunctions/build.gradle
+++ b/azurefunctions/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group 'com.microsoft.durabletask'
+version = '0.1.0-SNAPSHOT'
+archivesBaseName = 'durabletask-azurefunctions'
+
+def protocVersion = '3.12.0'
+
+dependencies {
+    api project(':sdk')
+    implementation group: 'com.microsoft.azure.functions', name: 'azure-functions-java-library', version: '1.4.2'
+    implementation "com.google.protobuf:protobuf-java:${protocVersion}"
+}
+
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            artifactId = archivesBaseName
+            from components.java
+        }
+    }
+}

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableActivityTrigger.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableActivityTrigger.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.durabletask.azurefunctions;
+
+import com.microsoft.azure.functions.annotation.CustomBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Azure Functions attribute for binding a function parameter to a Durable Task activity input.
+ * </p><p>
+ * The following is an example of an activity trigger function that accepts a String input and returns a String output.
+ * </p>
+ * <pre>
+ * {@literal @}FunctionName("SayHello")
+ * public String sayHello(
+ *         {@literal @}DurableActivityTrigger(name = "name") String name,
+ *         final ExecutionContext context) {
+ *     context.getLogger().info("Saying hello to: " + name);
+ *     return String.format("Hello %s!", name);
+ * }
+ * </pre>
+ * 
+ * @since 2.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@CustomBinding(direction = "in", name = "", type = "activityTrigger")
+public @interface DurableActivityTrigger {
+    /**
+     * <p>The name of the activity function.</p>
+     * <p>If not specified, the function name is used as the name of the activity.</p>
+     * <p>This property supports binding parameters.</p>
+     * 
+     * @return The name of the orchestrator function.
+     */
+    String activity() default "";
+    
+    /**
+     * The variable name used in function.json.
+     * 
+     * @return The variable name used in function.json.
+     */
+    String name();
+
+    /**
+     * <p>
+     * Defines how Functions runtime should treat the parameter value. Possible values are:
+     * </p>
+     * <ul>
+     * <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     * <li>string: always get the value as a string</li>
+     * <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     * 
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
+}

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableClientContext.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableClientContext.java
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.durabletask.azurefunctions;
+
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.DurableTaskGrpcClient;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The binding value type for the {@literal @}DurableClientInput parameter.
+ */
+public class DurableClientContext {
+    // These fields are populated via GSON deserialization by the Functions Java worker.
+    private String rpcBaseUrl;
+    private String taskHubName;
+    private String requiredQueryStringParameters;
+
+    /**
+     * Gets the name of the client binding's task hub.
+     *
+     * @return the name of the client binding's task hub.
+     */
+    public String getTaskHubName() {
+        return this.taskHubName;
+    }
+
+    /**
+     * Gets the durable task client associated with the current function invocation.
+     *
+     * @return the Durable Task client object associated with the current function invocation.
+     */
+    public DurableTaskClient getClient() {
+        if (this.rpcBaseUrl == null || this.rpcBaseUrl.length() == 0) {
+            throw new IllegalStateException("The client context wasn't populated with an RPC base URL!");
+        }
+
+        URL rpcURL;
+        try {
+            rpcURL = new URL(this.rpcBaseUrl);
+        } catch (MalformedURLException ex) {
+            throw new IllegalStateException("The client context RPC base URL was invalid!", ex);
+        }
+
+        return DurableTaskGrpcClient.newBuilder().forPort(rpcURL.getPort()).build();
+    }
+
+    public HttpResponseMessage createCheckStatusResponse(HttpRequestMessage<?> request, String instanceId) {
+        // TODO: To better support scenarios involving proxies or application gateways, this
+        //       code should take the X-Forwarded-Host, X-Forwarded-Proto, and Forwarded HTTP
+        //       request headers into consideration and generate the base URL accordingly.
+        //       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded.
+        //       One potential workaround is to set ASPNETCORE_FORWARDEDHEADERS_ENABLED to true.
+        String baseUrl = request.getUri().getScheme() + "://" + request.getUri().getAuthority();
+        String encodedInstanceId;
+        try {
+            encodedInstanceId = URLEncoder.encode(instanceId, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalArgumentException("Failed to encode the instance ID: " + instanceId, ex);
+        }
+
+        String instanceStatusURL = baseUrl + "/runtime/webhooks/durabletask/instances/" + encodedInstanceId;
+
+        // Construct the response as an HTTP 201 with a JSON object payload
+        return request.createResponseBuilder(HttpStatus.CREATED)
+                .header("Location", instanceStatusURL + "?" + this.requiredQueryStringParameters)
+                .header("Content-Type", "application/json")
+                .body(new HttpCreateCheckStatusResponse(
+                        instanceId,
+                        instanceStatusURL,
+                        this.requiredQueryStringParameters))
+                .build();
+            }
+
+    private static class HttpCreateCheckStatusResponse {
+        // These fields are serialized to JSON
+        public final String id;
+        public final String purgeHistoryDeleteUri;
+        public final String sendEventPostUri;
+        public final String statusQueryGetUri;
+        public final String terminatePostUri;
+
+        public HttpCreateCheckStatusResponse(
+                String instanceId,
+                String instanceStatusURL,
+                String requiredQueryStringParameters) {
+            this.id = instanceId;
+            this.purgeHistoryDeleteUri = instanceStatusURL + "?" + requiredQueryStringParameters;
+            this.sendEventPostUri = instanceStatusURL + "/raiseEvent/{eventName}?" + requiredQueryStringParameters;
+            this.statusQueryGetUri = instanceStatusURL + "?" + requiredQueryStringParameters;
+            this.terminatePostUri = instanceStatusURL + "/terminate?reason={text}&" + requiredQueryStringParameters;
+        }
+    }
+}

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableClientInput.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableClientInput.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.durabletask.azurefunctions;
+
+import com.microsoft.azure.functions.annotation.CustomBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Azure Functions attribute for binding a function parameter to a {@literal @}DurableClientContext object.
+ * </p><p>
+ * The following is an example of an HTTP-trigger function that uses this input binding to start a new
+ * orchestration instance.
+ * </p>
+ * <pre>
+ * {@literal @}FunctionName("StartHelloCities")
+ * public HttpResponseMessage startHelloCities(
+ *         {@literal @}HttpTrigger(name = "request", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+ *         {@literal @}DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+ *         final ExecutionContext context) {
+ * 
+ *     DurableTaskClient client = durableContext.getClient();
+ *     String instanceId = client.scheduleNewOrchestrationInstance("HelloCities");
+ *     context.getLogger().info("Created new Java orchestration with instance ID = " + instanceId);
+ *     return durableContext.createCheckStatusResponse(request, instanceId);
+ * }
+ * </pre>
+ * 
+ * @since 2.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@CustomBinding(direction = "in", name = "", type = "durableClient")
+public @interface DurableClientInput {
+    /**
+     * The variable name used in function.json.
+     * 
+     * @return The variable name used in function.json.
+     */
+    String name();
+
+    /**
+     * <p>
+     * Defines how Functions runtime should treat the parameter value. Possible values are:
+     * </p>
+     * <ul>
+     * <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     * <li>string: always get the value as a string</li>
+     * <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     * 
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
+
+    /**
+     * <p>
+     * Optional. The name of the task hub in which the orchestration data lives.
+     * </p>
+     * <p>
+     * If not specified, the task hub name used by this binding will be the value specified in host.json.
+     * If a task hub name is not configured in host.json and if the function app is running in the 
+     * Azure Functions hosted service, then task hub name is derived from the function app's name.
+     * Otherwise, a constant value is used for the task hub name.
+     * </p>
+     * <p>
+     * In general, you should <i>not</i> set a value for the task hub name here unless you intend to configure
+     * the client to interact with orchestrations in another app.
+     * </p>
+     * 
+     * @return The task hub name to use for the client.
+     */
+    String taskHub() default "";
+}

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableOrchestrationTrigger.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableOrchestrationTrigger.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.durabletask.azurefunctions;
+
+import com.microsoft.azure.functions.annotation.CustomBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Azure Functions attribute for binding a function parameter to a Durable Task orchestration request.
+ * </p><p>
+ * The following is an example of an orchestrator function that calls three activity functions in sequence.
+ * </p>
+ * <pre>
+ * {@literal @}FunctionName("HelloCities")
+ * public String helloCitiesOrchestrator(
+ *         {@literal @}DurableOrchestrationTrigger(name = "orchestratorRequestProtoBytes") String orchestratorRequestProtoBytes) {
+ *     return OrchestrationRunner.loadAndRun(orchestratorRequestProtoBytes, ctx -> {
+ *         String result = "";
+ *         result += ctx.callActivity("SayHello", "Tokyo", String.class).get() + ", ";
+ *         result += ctx.callActivity("SayHello", "London", String.class).get() + ", ";
+ *         result += ctx.callActivity("SayHello", "Seattle", String.class).get();
+ *         return result;
+ *     });
+ * }
+ * </pre>
+ * 
+ * @since 2.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@CustomBinding(direction = "in", name = "", type = "orchestrationTrigger")
+public @interface DurableOrchestrationTrigger {
+    /**
+     * <p>The name of the orchestrator function.</p>
+     * <p>If not specified, the function name is used as the name of the orchestration.</p>
+     * <p>This property supports binding parameters.</p>
+     * @return The name of the orchestrator function.
+     */
+    String orchestration() default "";
+
+    /**
+     * The variable name used in function.json.
+     * 
+     * @return The variable name used in function.json.
+     */
+    String name();
+
+    /**
+     * <p>
+     * Defines how Functions runtime should treat the parameter value. Possible values are:
+     * </p>
+     * <ul>
+     * <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     * <li>string: always get the value as a string</li>
+     * <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     * 
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "string";
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 subprojects {
   repositories {
+    mavenLocal()
     mavenCentral()
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,13 +1,14 @@
 plugins {
-    id 'java'
+    id 'java-library'
     id 'com.google.protobuf' version '0.8.16'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
+    id 'maven-publish'
 }
 
-group 'com.microsoft'
+group 'com.microsoft.durabletask'
 version = '0.1.0'
-archivesBaseName = 'durabletask'
+archivesBaseName = 'durabletask-sdk'
 
 def grpcVersion = '1.38.0'
 def protocVersion = '3.12.0'
@@ -75,3 +76,11 @@ task integrationTest(type: Test) {
     testLogging.showStandardStreams = true
 }
 
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            artifactId = archivesBaseName
+            from components.java
+        }
+    }
+}

--- a/sdk/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.microsoft.durabletask.protobuf.OrchestratorService;
+
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.logging.Logger;
+
+// TODO: Move this into the SDK since it shouldn't have any dependencies on Functions anymore
+// TODO: JavaDoc
+public final class OrchestrationRunner {
+    private static final Logger logger = Logger.getLogger(OrchestrationRunner.class.getPackage().getName());
+
+    public static <R> String loadAndRun(
+            String triggerStateProtoBase64String,
+            OrchestratorFunction<R> orchestratorFunc) {
+        byte[] decodedBytes = Base64.getDecoder().decode(triggerStateProtoBase64String);
+        byte[] resultBytes = loadAndRun(decodedBytes, orchestratorFunc);
+        return Base64.getEncoder().encodeToString(resultBytes);
+    }
+
+    public static <R> byte[] loadAndRun(
+            byte[] triggerStateProtoBytes,
+            OrchestratorFunction<R> orchestratorFunc) {
+        if (orchestratorFunc == null) {
+            throw new IllegalArgumentException("orchestratorFunc must not be null");
+        }
+
+        // Wrap the provided lambda in an anonymous TaskOrchestration
+        TaskOrchestration orchestration = ctx -> {
+            R output = orchestratorFunc.apply(ctx);
+            ctx.complete(output);
+        };
+
+        return loadAndRun(triggerStateProtoBytes, orchestration);
+    }
+
+    public static <R> String loadAndRun(
+            String triggerStateProtoBase64String,
+            TaskOrchestration orchestration) {
+        byte[] decodedBytes = Base64.getDecoder().decode(triggerStateProtoBase64String);
+        byte[] resultBytes = loadAndRun(decodedBytes, orchestration);
+        return Base64.getEncoder().encodeToString(resultBytes);
+    }
+
+    public static byte[] loadAndRun(byte[] triggerStateProtoBytes, TaskOrchestration orchestration) {
+        if (triggerStateProtoBytes == null || triggerStateProtoBytes.length == 0) {
+            throw new IllegalArgumentException("triggerStateProtoBytes must not be null or empty");
+        }
+
+        if (orchestration == null) {
+            throw new IllegalArgumentException("orchestration must not be null");
+        }
+
+        OrchestratorService.OrchestratorRequest orchestratorRequest;
+        try {
+            orchestratorRequest = OrchestratorService.OrchestratorRequest.parseFrom(triggerStateProtoBytes);
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException("triggerStateProtoBytes was not valid protobuf", e);
+        }
+
+        // Register the passed orchestration as the default ("*") orchestration
+        var orchestrationFactories = new HashMap<String, TaskOrchestrationFactory>();
+        orchestrationFactories.put("*", new TaskOrchestrationFactory() {
+            @Override
+            public String getName() {
+                return "*";
+            }
+
+            @Override
+            public TaskOrchestration create() {
+                return orchestration;
+            }
+        });
+
+        var taskOrchestrationExecutor = new TaskOrchestrationExecutor(
+                orchestrationFactories,
+                new JacksonDataConverter(),
+                logger);
+
+        // TODO: Error handling
+        Collection<OrchestratorService.OrchestratorAction> actions = taskOrchestrationExecutor.execute(
+                orchestratorRequest.getPastEventsList(),
+                orchestratorRequest.getNewEventsList());
+
+        // TODO: Need to get custom status from executor
+        OrchestratorService.OrchestratorResponse response = OrchestratorService.OrchestratorResponse.newBuilder()
+                .setInstanceId(orchestratorRequest.getInstanceId())
+                .addAllActions(actions)
+                .build();
+
+        return response.toByteArray();
+    }
+}

--- a/sdk/src/main/java/com/microsoft/durabletask/OrchestratorBlockedEvent.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/OrchestratorBlockedEvent.java
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 package com.microsoft.durabletask;
 
-public class OrchestratorYieldEvent extends Throwable {
-    OrchestratorYieldEvent(String message) {
+public class OrchestratorBlockedEvent extends Throwable {
+    OrchestratorBlockedEvent(String message) {
         super(message);
     }
 }

--- a/sdk/src/main/java/com/microsoft/durabletask/OrchestratorFunction.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/OrchestratorFunction.java
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+/**
+ * Functional interface for inline orchestrator functions.
+ */
+@FunctionalInterface
+public interface OrchestratorFunction<R> {
+    R apply(TaskOrchestrationContext ctx) throws OrchestratorBlockedEvent, TaskFailedException;
+}

--- a/sdk/src/main/java/com/microsoft/durabletask/Task.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/Task.java
@@ -21,7 +21,7 @@ public abstract class Task<V> {
         return this.future.isCancelled();
     }
 
-    public abstract V get() throws TaskFailedException, OrchestratorYieldEvent;
+    public abstract V get() throws TaskFailedException, OrchestratorBlockedEvent;
     public abstract Task<Void> thenRun(Runnable fn);
     public abstract Task<Void> thenAccept(Consumer<? super V> fn);
     public abstract <R> Task<R> thenApply(Function<? super V, ? extends R> fn);

--- a/sdk/src/main/java/com/microsoft/durabletask/TaskOrchestration.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/TaskOrchestration.java
@@ -3,5 +3,5 @@
 package com.microsoft.durabletask;
 
 public interface TaskOrchestration {
-    void run(TaskOrchestrationContext ctx) throws TaskFailedException, OrchestratorYieldEvent;
+    void run(TaskOrchestrationContext ctx) throws TaskFailedException, OrchestratorBlockedEvent;
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ":sdk"
+include ":azurefunctions"
 include ":samples"


### PR DESCRIPTION
This PR adds the following:

- A new project for Azure Functions annotations and binding types
- New APIs for implementing and running orchestrations as lambda functions
- Renamed `OrchestratorYieldEvent` to `OrchestratorBlockedEvent`, which feels like a more accurate name
- Updates Gradle dependency from 6.8 to 7.4.

Note that in order for the Azure Functions integration to work, two additional things are needed outside of this PR:

1. An updated Java worker that supports trigger return values.
2. An updated Durable Functions extension that supports the newer protobuf serialization format for orchestration trigger inputs and outputs.

In a later PR, I plan to add a simple sample function. Once the above dependencies are available, we can also create a CI workflow that runs the Functions sample end-to-end.