### PR TITLE
Support for "carryover" events

### DIFF
--- a/sdk/src/main/java/com/microsoft/durabletask/Helpers.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/Helpers.java
@@ -20,6 +20,12 @@ final class Helpers {
         }
     }
 
+    static void throwIfOrchestratorComplete(boolean isComplete) {
+        if (isComplete) {
+            throw new IllegalStateException("The orchestrator has already completed");
+        }
+    }
+
     static boolean isInfiniteTimeout(Duration timeout) {
         return timeout == null || timeout.isNegative() || timeout.equals(maxDuration);
     }


### PR DESCRIPTION
This PR is an update to @kaibocai's continue-as-new PR: https://github.com/microsoft/durabletask-java/pull/22

I discovered there were a few problems that prevented "carryover" events from working correctly. There were a few issues that needed to be addressed:

* The unprocessed external events needed to be sent back to the sidecar as "carryover" events. Sending events wasn't sufficient as I originally thought.
* The sidecar didn't support carryover events (it would fail with a TODO error message)

I have fixed both of these issues. The sidecar library has been updated on myget.org (see change [here](https://github.com/microsoft/durabletask-sidecar/commit/0f0030b99f44a254e839cdae0c8221a58dcdc080)) and I've also updated the `cgillum/durabletask-sidecar:latest` docker container image with these changes.

For this PR, I changed the behavior of the `continueAsNew` API to simply set some flags instead of creating the orchestration completed action. The orchestration completed action will be created only after all the history events have been played. This allows us to add all the unprocessed external event messages to the completed action's "carryover events" collection.

As a bonus, I added some checks to throw an exception if someone tries to take any action after an orchestrator has completed. Users shouldn't be doing this, and the behavior would otherwise be undefined.

I also made some minor changes to the test logic.