### PR TITLE
Added new allOf convenience overload

### DIFF
--- a/sdk/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/sdk/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -17,6 +17,11 @@ public interface TaskOrchestrationContext {
     boolean getIsReplaying();
     <V> Task<V> completedTask(V value);
     <V> Task<List<V>> allOf(List<Task<V>> tasks);
+
+    default <V> Task<List<V>> allOf(Task<V>... tasks) {
+        return this.allOf(Arrays.asList(tasks));
+    }
+
     Task<Task<?>> anyOf(List<Task<?>> tasks);
 
     default Task<Task<?>> anyOf(Task<?>... tasks) {


### PR DESCRIPTION
This is a convenience overload of `anyOf` that allows a cleaner syntax when you have a fixed number of activities for fan-out/fan-in. I decided to add this after working on documentation and code samples. Here's the sample that uses this overload:

```java
@FunctionName("NewBuildingPermit")
public String newBuildingPermit(
    @DurableOrchestrationTrigger(name = "runtimeState") String runtimeState) {
        return OrchestrationRunner.loadAndRun(runtimeState, ctx -> {
            String applicationId = ctx.getInput(String.class);

            Task<Void> gate1 = ctx.waitForExternalEvent("CityPlanningApproval");
            Task<Void> gate2 = ctx.waitForExternalEvent("FireDeptApproval");
            Task<Void> gate3 = ctx.waitForExternalEvent("BuildingDeptApproval");

            // all three departments must grant approval before a permit can be issued
            ctx.allOf(gate1, gate2, gate3).get();

            ctx.callActivity("IssueBuildingPermit", applicationId).get();
        });
}
```

Basically, it removes the need to wrap the list of tasks in something like `Arrays.asList(...)`.

The other reason to add this is for consistency with `anyOf`, which already has a similar overload.