### PR TITLE
waitForOrchestrationStart/Complete methods throw TimeoutException when grpc deadline exceeded

### DIFF
--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -4,6 +4,7 @@ package com.microsoft.durabletask;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Base class that defines client operations for managing orchestration instances.
@@ -140,10 +141,11 @@ public abstract class DurableTaskClient implements AutoCloseable {
      *
      * @param instanceId the unique ID of the orchestration instance to wait for
      * @param timeout the amount of time to wait for the orchestration instance to start
+     * @throws TimeoutException when the orchestration instance is not started within the specified amount of time
      * @return the orchestration instance metadata or <code>null</code> if no such instance is found
      */
     @Nullable
-    public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout) {
+    public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout) throws TimeoutException {
         return this.waitForInstanceStart(instanceId, timeout, false);
     }
 
@@ -159,13 +161,14 @@ public abstract class DurableTaskClient implements AutoCloseable {
      * @param timeout the amount of time to wait for the orchestration instance to start
      * @param getInputsAndOutputs <code>true</code> to fetch the orchestration instance's inputs, outputs, and custom
      *                            status, or <code>false</code> to omit them
+     * @throws TimeoutException when the orchestration instance is not started within the specified amount of time
      * @return the orchestration instance metadata or <code>null</code> if no such instance is found
      */
     @Nullable
     public abstract OrchestrationMetadata waitForInstanceStart(
             String instanceId,
             Duration timeout,
-            boolean getInputsAndOutputs);
+            boolean getInputsAndOutputs) throws TimeoutException;
 
     /**
      * Waits for an orchestration to complete and returns an {@link OrchestrationMetadata} object that contains
@@ -184,13 +187,14 @@ public abstract class DurableTaskClient implements AutoCloseable {
      * @param timeout the amount of time to wait for the orchestration instance to complete
      * @param getInputsAndOutputs <code>true</code> to fetch the orchestration instance's inputs, outputs, and custom
      *                            status, or <code>false</code> to omit them
+     * @throws TimeoutException when the orchestration instance is not completed within the specified amount of time
      * @return the orchestration instance metadata or <code>null</code> if no such instance is found
      */
     @Nullable
     public abstract OrchestrationMetadata waitForInstanceCompletion(
             String instanceId,
             Duration timeout,
-            boolean getInputsAndOutputs);
+            boolean getInputsAndOutputs) throws TimeoutException;
 
     /**
      * Terminates a running orchestration instance and updates its runtime status to <code>Terminated</code>.

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -162,7 +162,7 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
             response = grpcClient.waitForInstanceStart(request);
         } catch (StatusRuntimeException e) {
             if (e.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
-                throw new TimeoutException("Start orchestration timeout reached");
+                throw new TimeoutException("Start orchestration timeout reached.");
             }
             throw e;
         }
@@ -189,7 +189,7 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
             response = grpcClient.waitForInstanceCompletion(request);
         } catch (StatusRuntimeException e) {
             if (e.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
-                throw new TimeoutException("Orchestration instance completion timeout reached");
+                throw new TimeoutException("Orchestration instance completion timeout reached.");
             }
             throw e;
         }

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 /**
@@ -142,7 +143,7 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
     }
 
     @Override
-    public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout, boolean getInputsAndOutputs) {
+    public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout, boolean getInputsAndOutputs) throws TimeoutException {
         GetInstanceRequest request = GetInstanceRequest.newBuilder()
                 .setInstanceId(instanceId)
                 .setGetInputsAndOutputs(getInputsAndOutputs)
@@ -155,12 +156,21 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
         TaskHubSidecarServiceBlockingStub grpcClient = this.sidecarClient.withDeadlineAfter(
                 timeout.toMillis(),
                 TimeUnit.MILLISECONDS);
-        GetInstanceResponse response = grpcClient.waitForInstanceStart(request);
+
+        GetInstanceResponse response;
+        try {
+            response = grpcClient.waitForInstanceStart(request);
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                throw new TimeoutException("Start orchestration timeout reached");
+            }
+            throw e;
+        }
         return new OrchestrationMetadata(response, this.dataConverter, request.getGetInputsAndOutputs());
     }
 
     @Override
-    public OrchestrationMetadata waitForInstanceCompletion(String instanceId, Duration timeout, boolean getInputsAndOutputs) {
+    public OrchestrationMetadata waitForInstanceCompletion(String instanceId, Duration timeout, boolean getInputsAndOutputs) throws TimeoutException {
         GetInstanceRequest request = GetInstanceRequest.newBuilder()
                 .setInstanceId(instanceId)
                 .setGetInputsAndOutputs(getInputsAndOutputs)
@@ -173,7 +183,16 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
         TaskHubSidecarServiceBlockingStub grpcClient = this.sidecarClient.withDeadlineAfter(
                 timeout.toMillis(),
                 TimeUnit.MILLISECONDS);
-        GetInstanceResponse response = grpcClient.waitForInstanceCompletion(request);
+
+        GetInstanceResponse response;
+        try {
+            response = grpcClient.waitForInstanceCompletion(request);
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                throw new TimeoutException("Orchestration instance completion timeout reached");
+            }
+            throw e;
+        }
         return new OrchestrationMetadata(response, this.dataConverter, request.getGetInputsAndOutputs());
     }
 

--- a/client/src/test/java/com/microsoft/durabletask/ErrorHandlingIntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/ErrorHandlingIntegrationTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -24,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("integration")
 public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
     @Test
-    void orchestratorException() {
+    void orchestratorException() throws TimeoutException {
         final String orchestratorName = "OrchestratorWithException";
         final String errorMessage = "Kah-BOOOOOM!!!";
 
@@ -51,7 +52,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void activityException(boolean handleException) {
+    void activityException(boolean handleException) throws TimeoutException {
         final String orchestratorName = "OrchestratorWithActivityException";
         final String activityName = "Throw";
         final String errorMessage = "Kah-BOOOOOM!!!";
@@ -103,7 +104,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10})
-    public void retryActivityFailures(int maxNumberOfAttempts) {
+    public void retryActivityFailures(int maxNumberOfAttempts) throws TimeoutException {
         // There is one task for each activity call and one task between each retry
         int expectedTaskCount = (maxNumberOfAttempts * 2) - 1;
         this.retryOnFailuresCoreTest(maxNumberOfAttempts, expectedTaskCount, ctx -> {
@@ -117,7 +118,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10})
-    public void retryActivityFailuresWithCustomLogic(int maxNumberOfAttempts) {
+    public void retryActivityFailuresWithCustomLogic(int maxNumberOfAttempts) throws TimeoutException {
         // This gets incremented every time the retry handler is invoked
         AtomicInteger retryHandlerCalls = new AtomicInteger();
 
@@ -134,7 +135,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void subOrchestrationException(boolean handleException){
+    void subOrchestrationException(boolean handleException) throws TimeoutException {
         final String orchestratorName = "OrchestrationWithBustedSubOrchestrator";
         final String subOrchestratorName = "BustedSubOrchestrator";
         final String errorMessage = "Kah-BOOOOOM!!!";
@@ -184,7 +185,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10})
-    public void retrySubOrchestratorFailures(int maxNumberOfAttempts) {
+    public void retrySubOrchestratorFailures(int maxNumberOfAttempts) throws TimeoutException {
         // There is one task for each sub-orchestrator call and one task between each retry
         int expectedTaskCount = (maxNumberOfAttempts * 2) - 1;
         this.retryOnFailuresCoreTest(maxNumberOfAttempts, expectedTaskCount, ctx -> {
@@ -199,7 +200,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10})
-    public void retrySubOrchestrationFailuresWithCustomLogic(int maxNumberOfAttempts) {
+    public void retrySubOrchestrationFailuresWithCustomLogic(int maxNumberOfAttempts) throws TimeoutException {
         // This gets incremented every time the retry handler is invoked
         AtomicInteger retryHandlerCalls = new AtomicInteger();
 
@@ -252,7 +253,7 @@ public class ErrorHandlingIntegrationTests extends IntegrationTestBase {
     private FailureDetails retryOnFailuresCoreTest(
             int maxNumberOfAttempts,
             int expectedTaskCount,
-            TaskOrchestration mainOrchestration) {
+            TaskOrchestration mainOrchestration) throws TimeoutException {
         final String orchestratorName = "MainOrchestrator";
 
         AtomicInteger actualAttemptCount = new AtomicInteger();

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -796,6 +796,7 @@ public class IntegrationTests extends IntegrationTestBase {
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
                 .addOrchestrator(orchestratorName, ctx -> {
                     try {
+                        // The orchestration remains in the "Pending" state until the first await statement
                         TimeUnit.SECONDS.sleep(5);
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
@@ -823,6 +824,7 @@ public class IntegrationTests extends IntegrationTestBase {
                 })
                 .addActivity(plusOneActivityName, ctx -> {
                     try {
+                        // The orchestration is started but not completed within the orchestration completion timeout due the below activity delay
                         TimeUnit.SECONDS.sleep(5);
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -40,7 +42,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void emptyOrchestration() {
+    void emptyOrchestration() throws TimeoutException {
         final String orchestratorName = "EmptyOrchestration";
         final String input = "Hello " + Instant.now();
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
@@ -63,7 +65,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void singleTimer() throws IOException {
+    void singleTimer() throws IOException, TimeoutException {
         final String orchestratorName = "SingleTimer";
         final Duration delay = Duration.ofSeconds(3);
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
@@ -86,7 +88,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void isReplaying() throws IOException, InterruptedException {
+    void isReplaying() throws IOException, InterruptedException, TimeoutException {
         final String orchestratorName = "SingleTimer";
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
             .addOrchestrator(orchestratorName, ctx -> {
@@ -122,7 +124,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void singleActivity() throws IOException, InterruptedException {
+    void singleActivity() throws IOException, InterruptedException, TimeoutException {
         final String orchestratorName = "SingleActivity";
         final String activityName = "Echo";
         final String input = Instant.now().toString();
@@ -154,7 +156,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void currentDateTimeUtc() throws IOException {
+    void currentDateTimeUtc() throws IOException, TimeoutException {
         final String orchestratorName = "CurrentDateTimeUtc";
         final String echoActivityName = "Echo";
 
@@ -193,7 +195,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void activityChain() throws IOException {
+    void activityChain() throws IOException, TimeoutException {
         final String orchestratorName = "ActivityChain";
         final String plusOneActivityName = "PlusOne";
 
@@ -220,7 +222,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void subOrchestration(){
+    void subOrchestration() throws TimeoutException {
         final String orchestratorName = "SubOrchestration";
         DurableTaskGrpcWorker worker = this.createWorkerBuilder().addOrchestrator(orchestratorName, ctx -> {
             int result = 5;
@@ -241,7 +243,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void continueAsNew(){
+    void continueAsNew() throws TimeoutException {
         final String orchestratorName = "continueAsNew";
         final Duration delay = Duration.ofSeconds(0);
         DurableTaskGrpcWorker worker = this.createWorkerBuilder().addOrchestrator(orchestratorName, ctx -> {
@@ -264,7 +266,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void continueAsNewWithExternalEvents() {
+    void continueAsNewWithExternalEvents() throws TimeoutException {
         final String orchestratorName = "continueAsNewWithExternalEvents";
         final String eventName = "MyEvent";
         final int expectedEventCount = 10;
@@ -295,7 +297,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void termination() {
+    void termination() throws TimeoutException {
         final String orchestratorName = "Termination";
         final Duration delay = Duration.ofSeconds(3);
 
@@ -317,7 +319,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void activityFanOut() throws IOException {
+    void activityFanOut() throws IOException, TimeoutException {
         final String orchestratorName = "ActivityFanOut";
         final String activityName = "ToString";
         final int activityCount = 10;
@@ -359,7 +361,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void externalEvents() throws IOException {
+    void externalEvents() throws IOException, TimeoutException {
         final String orchestratorName = "ExternalEvents";
         final String eventName = "MyEvent";
         final int eventCount = 10;
@@ -399,7 +401,7 @@ public class IntegrationTests extends IntegrationTestBase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void externalEventsWithTimeouts(boolean raiseEvent) throws IOException {
+    void externalEventsWithTimeouts(boolean raiseEvent) throws IOException, TimeoutException {
         final String orchestratorName = "ExternalEventsWithTimeouts";
         final String eventName = "MyEvent";
 
@@ -437,7 +439,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void setCustomStatus() {
+    void setCustomStatus() throws TimeoutException {
         final String orchestratorName = "SetCustomStatus";
 
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
@@ -470,7 +472,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void clearCustomStatus() {
+    void clearCustomStatus() throws TimeoutException {
         final String orchestratorName = "ClearCustomStatus";
 
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
@@ -499,7 +501,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void multiInstanceQuery() {
+    void multiInstanceQuery() throws TimeoutException{
         final String plusOne = "plusOne";
         final String waitForEvent = "waitForEvent";
         final DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
@@ -528,7 +530,11 @@ public class IntegrationTests extends IntegrationTestBase {
                 client.scheduleNewOrchestrationInstance(plusOne, 0, instanceId);
                 return instanceId;
             }).collect(Collectors.toUnmodifiableList()).forEach(id -> {
-                client.waitForInstanceCompletion(id, defaultTimeout, true);
+                try {
+                    client.waitForInstanceCompletion(id, defaultTimeout, true);
+                } catch (TimeoutException e) {
+                    e.printStackTrace();
+                }
             });
 
             Instant sequencesFinishedTime = Instant.now();
@@ -538,7 +544,11 @@ public class IntegrationTests extends IntegrationTestBase {
                 client.scheduleNewOrchestrationInstance(waitForEvent, String.valueOf(i), instanceId);
                 return instanceId;
             }).collect(Collectors.toUnmodifiableList()).forEach(id -> {
-                client.waitForInstanceStart(id, defaultTimeout);
+                try {
+                    client.waitForInstanceStart(id, defaultTimeout);
+                } catch (TimeoutException e) {
+                    e.printStackTrace();
+                }
             });
 
             // Create one query object and reuse it for multiple queries
@@ -652,7 +662,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void purgeInstanceId() {
+    void purgeInstanceId() throws TimeoutException {
         final String orchestratorName = "PurgeInstance";
         final String plusOneActivityName = "PlusOne";
 
@@ -683,7 +693,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void purgeInstanceFilter() {
+    void purgeInstanceFilter() throws TimeoutException {
         final String orchestratorName = "PurgeInstance";
         final String plusOne = "PlusOne";
         final String plusTwo = "PlusTwo";
@@ -776,6 +786,56 @@ public class IntegrationTests extends IntegrationTestBase {
             assertFalse(metadata.isInstanceFound());
             metadata = client.getInstanceMetadata(instanceId3, true);
             assertFalse(metadata.isInstanceFound());
+        }
+    }
+
+    @Test()
+    void waitForInstanceStartThrowsException() {
+        final String orchestratorName = "orchestratorName";
+
+        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
+                .addOrchestrator(orchestratorName, ctx -> {
+                    try {
+                        TimeUnit.SECONDS.sleep(5);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .buildAndStart();
+
+        DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
+        try (worker; client) {
+            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName);
+            assertThrows(TimeoutException.class, () -> client.waitForInstanceStart(instanceId, Duration.ofSeconds(2)));
+        }
+    }
+
+    @Test()
+    void waitForInstanceCompletionThrowsException() {
+        final String orchestratorName = "orchestratorName";
+        final String plusOneActivityName = "PlusOne";
+
+        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
+                .addOrchestrator(orchestratorName, ctx -> {
+                    int value = ctx.getInput(int.class);
+                    value = ctx.callActivity(plusOneActivityName, value, int.class).await();
+                    ctx.complete(value);
+                })
+                .addActivity(plusOneActivityName, ctx -> {
+                    try {
+                        TimeUnit.SECONDS.sleep(5);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return ctx.getInput(int.class) + 1;
+                })
+                .buildAndStart();
+
+        DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
+        try (worker; client) {
+            client.createTaskHub(true);
+            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName, 0);
+            assertThrows(TimeoutException.class, () -> client.waitForInstanceCompletion(instanceId, Duration.ofSeconds(2), false));
         }
     }
 }

--- a/samples/src/main/java/io/durabletask/samples/ChainingPattern.java
+++ b/samples/src/main/java/io/durabletask/samples/ChainingPattern.java
@@ -6,9 +6,10 @@ import com.microsoft.durabletask.*;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 final class ChainingPattern {
-    public static void main(String[] args) throws IOException, InterruptedException {
+    public static void main(String[] args) throws IOException, InterruptedException, TimeoutException {
         // The TaskHubServer listens over gRPC for new orchestration and activity execution requests
         final DurableTaskGrpcWorker server = createTaskHubServer();
 

--- a/samples/src/main/java/io/durabletask/samples/FanOutFanInPattern.java
+++ b/samples/src/main/java/io/durabletask/samples/FanOutFanInPattern.java
@@ -9,11 +9,12 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 class FanOutFanInPattern {
 
-    public static void main(String[] args) throws IOException, InterruptedException {
+    public static void main(String[] args) throws IOException, InterruptedException, TimeoutException {
         // The TaskHubServer listens over gRPC for new orchestration and activity execution requests
         final DurableTaskGrpcWorker worker = createWorker();
 


### PR DESCRIPTION
- waitForOrchestrationStart/Complete methods throw TimeoutException when grpc deadline exceeded
- added unit tests
- updated docs 


resolves #62 