### PR TITLE
Throw CompositeTaskFailedException for context.allOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### New
 
 * Add CHANGELOG.md file to track changes across versions
+* context.allOf() throws CompositeTaskFailedException(RuntimeException) when one or more tasks fail ([#54](https://github.com/microsoft/durabletask-java/issues/54))
+
 
 ### Updates
 

--- a/client/src/main/java/com/microsoft/durabletask/CompositeTaskFailedException.java
+++ b/client/src/main/java/com/microsoft/durabletask/CompositeTaskFailedException.java
@@ -49,7 +49,7 @@ public class CompositeTaskFailedException extends RuntimeException {
      *
      * @return a list of exceptions
      */
-    List<Exception> getExceptions() {
+    public List<Exception> getExceptions() {
         return new ArrayList<>(this.exceptions);
     }
 

--- a/client/src/main/java/com/microsoft/durabletask/CompositeTaskFailedException.java
+++ b/client/src/main/java/com/microsoft/durabletask/CompositeTaskFailedException.java
@@ -1,40 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 package com.microsoft.durabletask;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class CompositeTaskFailedException extends Exception{
+/**
+ * Exception that gets thrown when multiple {@link Task}s for an activity or sub-orchestration fails with an
+ * unhandled exception.
+ * <p>
+ * Detailed information associated with each task failure can be retrieved using the {@link #getExceptions()}
+ * method.
+ */
+public class CompositeTaskFailedException extends RuntimeException {
     private final List<Exception> exceptions;
 
-    public CompositeTaskFailedException() {
+    CompositeTaskFailedException() {
         this.exceptions = new ArrayList<>();
     }
 
-    public CompositeTaskFailedException(List<Exception> exceptions) {
+    CompositeTaskFailedException(List<Exception> exceptions) {
         this.exceptions = exceptions;
     }
 
-    public CompositeTaskFailedException(String message, List<Exception> exceptions) {
+    CompositeTaskFailedException(String message, List<Exception> exceptions) {
         super(message);
         this.exceptions = exceptions;
     }
 
-    public CompositeTaskFailedException(String message, Throwable cause, List<Exception> exceptions) {
+    CompositeTaskFailedException(String message, Throwable cause, List<Exception> exceptions) {
         super(message, cause);
         this.exceptions = exceptions;
     }
 
-    public CompositeTaskFailedException(Throwable cause, List<Exception> exceptions) {
+    CompositeTaskFailedException(Throwable cause, List<Exception> exceptions) {
         super(cause);
         this.exceptions = exceptions;
     }
 
-    public CompositeTaskFailedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, List<Exception> exceptions) {
+    CompositeTaskFailedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, List<Exception> exceptions) {
         super(message, cause, enableSuppression, writableStackTrace);
         this.exceptions = exceptions;
     }
 
-    public List<Exception> getExceptions() {
+    /**
+     * Gets a list of exceptions that occurred during execution of a group of {@link Task}
+     * These exceptions include details of the task failure and exception information
+     *
+     * @return a list of exceptions
+     */
+    List<Exception> getExceptions() {
         return new ArrayList<>(this.exceptions);
     }
 

--- a/client/src/main/java/com/microsoft/durabletask/CompositeTaskFailedException.java
+++ b/client/src/main/java/com/microsoft/durabletask/CompositeTaskFailedException.java
@@ -1,0 +1,41 @@
+package com.microsoft.durabletask;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompositeTaskFailedException extends Exception{
+    private final List<Exception> exceptions;
+
+    public CompositeTaskFailedException() {
+        this.exceptions = new ArrayList<>();
+    }
+
+    public CompositeTaskFailedException(List<Exception> exceptions) {
+        this.exceptions = exceptions;
+    }
+
+    public CompositeTaskFailedException(String message, List<Exception> exceptions) {
+        super(message);
+        this.exceptions = exceptions;
+    }
+
+    public CompositeTaskFailedException(String message, Throwable cause, List<Exception> exceptions) {
+        super(message, cause);
+        this.exceptions = exceptions;
+    }
+
+    public CompositeTaskFailedException(Throwable cause, List<Exception> exceptions) {
+        super(cause);
+        this.exceptions = exceptions;
+    }
+
+    public CompositeTaskFailedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, List<Exception> exceptions) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.exceptions = exceptions;
+    }
+
+    public List<Exception> getExceptions() {
+        return new ArrayList<>(this.exceptions);
+    }
+
+}

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -81,8 +81,8 @@ public interface TaskOrchestrationContext {
      * <pre>{@code
      * try {
      *     List<String> orderedResults = ctx.allOf(List.of(t1, t2, t3)).await();
-     * } catch{
-     *     e.getExceptions()
+     * } catch (CompositeTaskFailedException e) {
+     *     List<Exception> exceptions = e.getExceptions()
      * }
      * }</pre>
      *

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -80,7 +80,7 @@ public interface TaskOrchestrationContext {
      * @param <V> the return type of the {@code Task} objects
      * @return the values of the completed {@code Task} objects in the same order as the source list
      */
-    <V> Task<List<V>> allOf(List<Task<V>> tasks) throws CompositeTaskFailedException;
+    <V> Task<List<V>> allOf(List<Task<V>> tasks);
 
     /**
      * Returns a new {@code Task} that is completed when any of the tasks in {@code tasks} completes.

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -61,7 +61,7 @@ public interface TaskOrchestrationContext {
     //       https://github.com/microsoft/durabletask-java/issues/54
     /**
      * Returns a new {@code Task} that is completed when all the given {@code Task}s complete. If any of the given
-     * {@code Task}s complete with an exception, the returned {@code Task} will also complete with an exception
+     * {@code Task}s complete with an exception, the returned {@code Task} will also complete with an {@link CompositeTaskFailedException}
      * containing details of the first encountered failure. The value of the returned {@code Task} is an ordered list of
      * the return values of the given tasks. If no tasks are provided, returns a {@code Task} completed with value
      * {@code null}.
@@ -74,6 +74,16 @@ public interface TaskOrchestrationContext {
      * Task<String> t3 = ctx.callActivity("MyActivity", String.class);
      *
      * List<String> orderedResults = ctx.allOf(List.of(t1, t2, t3)).await();
+     * }</pre>
+     *
+     * Exceptions in any of the given tasks results in an unchecked {@link CompositeTaskFailedException}.
+     * This exception can be inspected to obtain failure details of individual {@link Task}s.
+     * <pre>{@code
+     * try {
+     *     List<String> orderedResults = ctx.allOf(List.of(t1, t2, t3)).await();
+     * } catch{
+     *     e.getExceptions()
+     * }
      * }</pre>
      *
      * @param tasks the list of {@code Task} objects

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -80,7 +80,7 @@ public interface TaskOrchestrationContext {
      * @param <V> the return type of the {@code Task} objects
      * @return the values of the completed {@code Task} objects in the same order as the source list
      */
-    <V> Task<List<V>> allOf(List<Task<V>> tasks);
+    <V> Task<List<V>> allOf(List<Task<V>> tasks) throws CompositeTaskFailedException;
 
     /**
      * Returns a new {@code Task} that is completed when any of the tasks in {@code tasks} completes.

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -180,7 +180,7 @@ final class TaskOrchestrationExecutor {
                             try {
                                 results.add(cf.get());
                             } catch (Exception ex) {
-                                throw new RuntimeException("One or more tasks failed.", ex);
+                                results.add(null);
                             }
                         }
                         return results;
@@ -194,7 +194,7 @@ final class TaskOrchestrationExecutor {
                                 exceptions.add(ex);
                             }
                         }
-                        throw new CompositeTaskFailedException("One or more tasks failed.", exceptions);
+                        throw new CompositeTaskFailedException(exceptions.get(0).getCause().getMessage(), exceptions);
                     })
             );
         }

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -196,7 +196,12 @@ final class TaskOrchestrationExecutor {
                                 exceptions.add(ex);
                             }
                         }
-                        throw new CompositeTaskFailedException(exceptions.get(0).getMessage(), exceptions);
+                        throw new CompositeTaskFailedException(
+                                String.format(
+                                        "%d out of %d tasks failed with an exception. See the exceptions list for details.",
+                                        exceptions.size(),
+                                        futures.length),
+                                exceptions);
                     })
             );
         }

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -190,11 +190,13 @@ final class TaskOrchestrationExecutor {
                         for (CompletableFuture<V> cf : futures) {
                             try {
                                 cf.get();
-                            } catch (Exception ex) {
+                            } catch (ExecutionException ex) {
+                                exceptions.add((Exception) ex.getCause());
+                            } catch (Exception ex){
                                 exceptions.add(ex);
                             }
                         }
-                        throw new CompositeTaskFailedException(exceptions.get(0).getCause().getMessage(), exceptions);
+                        throw new CompositeTaskFailedException(exceptions.get(0).getMessage(), exceptions);
                     })
             );
         }

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -843,7 +843,7 @@ public class IntegrationTests extends IntegrationTestBase {
     }
 
     @Test
-    void activityFanOutWithException() {
+    void activityFanOutWithException() throws TimeoutException {
         final String orchestratorName = "ActivityFanOut";
         final String activityName = "Divide";
         final int count = 10;

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -866,8 +866,9 @@ public class IntegrationTests extends IntegrationTestBase {
                         assertEquals(ExecutionException.class, e.getExceptions().get(1).getClass());
                         assertEquals(TaskFailedException.class, e.getExceptions().get(0).getCause().getClass());
                         assertEquals(TaskFailedException.class, e.getExceptions().get(1).getCause().getClass());
-                        assertTrue(e.getExceptions().get(0).getCause().getMessage().contains("unhandled exception: / by zero"));
-                        assertTrue(e.getExceptions().get(1).getCause().getMessage().contains("unhandled exception: / by zero"));
+                        // taskId in the exception below is based on parallelTasks input
+                        assertEquals(getExceptionMessage(activityName, 2, "/ by zero"), e.getExceptions().get(0).getCause().getMessage());
+                        assertEquals(getExceptionMessage(activityName, 4, "/ by zero"), e.getExceptions().get(1).getCause().getMessage());
                         throw e;
                     }
                 })
@@ -886,9 +887,16 @@ public class IntegrationTests extends IntegrationTestBase {
 
             FailureDetails details = instance.getFailureDetails();
             assertNotNull(details);
-            assertEquals("One or more tasks failed.", details.getErrorMessage());
+            assertEquals(getExceptionMessage(activityName, 2, "/ by zero"), details.getErrorMessage());
             assertEquals("com.microsoft.durabletask.CompositeTaskFailedException", details.getErrorType());
             assertNotNull(details.getStackTrace());
         }
+    }
+    private static String getExceptionMessage(String taskName, int expectedTaskId, String expectedExceptionMessage) {
+        return String.format(
+                "Task '%s' (#%d) failed with an unhandled exception: %s",
+                taskName,
+                expectedTaskId,
+                expectedExceptionMessage);
     }
 }

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -847,6 +847,7 @@ public class IntegrationTests extends IntegrationTestBase {
         final String orchestratorName = "ActivityFanOut";
         final String activityName = "Divide";
         final int count = 10;
+        final String exceptionMessage = "2 out of 6 tasks failed with an exception. See the exceptions list for details.";
 
         DurableTaskGrpcWorker worker = this.createWorkerBuilder()
                 .addOrchestrator(orchestratorName, ctx -> {
@@ -885,7 +886,7 @@ public class IntegrationTests extends IntegrationTestBase {
 
             FailureDetails details = instance.getFailureDetails();
             assertNotNull(details);
-            assertEquals(getExceptionMessage(activityName, 2, "/ by zero"), details.getErrorMessage());
+            assertEquals(exceptionMessage, details.getErrorMessage());
             assertEquals("com.microsoft.durabletask.CompositeTaskFailedException", details.getErrorType());
             assertNotNull(details.getStackTrace());
         }

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -862,13 +862,11 @@ public class IntegrationTests extends IntegrationTestBase {
                     }catch (CompositeTaskFailedException e){
                         assertNotNull(e);
                         assertEquals(2, e.getExceptions().size());
-                        assertEquals(ExecutionException.class, e.getExceptions().get(0).getClass());
-                        assertEquals(ExecutionException.class, e.getExceptions().get(1).getClass());
-                        assertEquals(TaskFailedException.class, e.getExceptions().get(0).getCause().getClass());
-                        assertEquals(TaskFailedException.class, e.getExceptions().get(1).getCause().getClass());
+                        assertEquals(TaskFailedException.class, e.getExceptions().get(0).getClass());
+                        assertEquals(TaskFailedException.class, e.getExceptions().get(1).getClass());
                         // taskId in the exception below is based on parallelTasks input
-                        assertEquals(getExceptionMessage(activityName, 2, "/ by zero"), e.getExceptions().get(0).getCause().getMessage());
-                        assertEquals(getExceptionMessage(activityName, 4, "/ by zero"), e.getExceptions().get(1).getCause().getMessage());
+                        assertEquals(getExceptionMessage(activityName, 2, "/ by zero"), e.getExceptions().get(0).getMessage());
+                        assertEquals(getExceptionMessage(activityName, 4, "/ by zero"), e.getExceptions().get(1).getMessage());
                         throw e;
                     }
                 })

--- a/samples/src/main/java/io/durabletask/samples/FanOutFanInPattern.java
+++ b/samples/src/main/java/io/durabletask/samples/FanOutFanInPattern.java
@@ -71,12 +71,7 @@ class FanOutFanInPattern {
                             .collect(Collectors.toList());
 
                     // Fan-in to get the total word count from all the individual activity results.
-                    List<Integer> allWordCountResults;
-                    try {
-                        allWordCountResults = ctx.allOf(tasks).await();
-                    } catch (CompositeTaskFailedException e) {
-                        throw new RuntimeException(e);
-                    }
+                    List<Integer> allWordCountResults = ctx.allOf(tasks).await();
                     int totalWordCount = allWordCountResults.stream().mapToInt(Integer::intValue).sum();
 
                     // Save the final result as the orchestration output.

--- a/samples/src/main/java/io/durabletask/samples/FanOutFanInPattern.java
+++ b/samples/src/main/java/io/durabletask/samples/FanOutFanInPattern.java
@@ -71,7 +71,12 @@ class FanOutFanInPattern {
                             .collect(Collectors.toList());
 
                     // Fan-in to get the total word count from all the individual activity results.
-                    List<Integer> allWordCountResults = ctx.allOf(tasks).await();
+                    List<Integer> allWordCountResults;
+                    try {
+                        allWordCountResults = ctx.allOf(tasks).await();
+                    } catch (CompositeTaskFailedException e) {
+                        throw new RuntimeException(e);
+                    }
                     int totalWordCount = allWordCountResults.stream().mapToInt(Integer::intValue).sum();
 
                     // Save the final result as the orchestration output.


### PR DESCRIPTION

TaskOrchestrationContext.allOf should throw TaskFailureException instead of RuntimeException
- code changes 
- unit tests 
- documentation changes

resolves #54 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)