### PR TITLE
Additional updates to the v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,17 @@
 ### New
 
 * Add CHANGELOG.md file to track changes across versions
-* context.allOf() throws CompositeTaskFailedException(RuntimeException) when one or more tasks fail ([#54](https://github.com/microsoft/durabletask-java/issues/54))
-
 
 ### Updates
 
 * update DataConverterException with detail error message ([#78](https://github.com/microsoft/durabletask-java/issues/78))
 * update OrchestratorBlockedEvent and TaskFailedException to be unchecked exceptions ([#88](https://github.com/microsoft/durabletask-java/issues/88))
-* updated PurgeInstances to take a timeout parameter and throw TimeoutException ([#37](https://github.com/microsoft/durabletask-java/issues/37))
 * update dependency azure-functions-java-library to 2.2.0 - include azure-functions-java-spi as `compileOnly` dependency ([#95](https://github.com/microsoft/durabletask-java/pull/95))
 
 ### Breaking changes
 
 * Use java worker middleware to avoid wrapper method when create orchestrator function ([#87](https://github.com/microsoft/durabletask-java/pull/87))
 * Fixed DurableClientContext.createCheckStatusResponse to return 202 ([#92](https://github.com/microsoft/durabletask-java/pull/92))
+* context.allOf() now throws CompositeTaskFailedException(RuntimeException) when one or more tasks fail ([#54](https://github.com/microsoft/durabletask-java/issues/54))
+* Updated `DurableTaskClient.purgeInstances(...)` to take a timeout parameter and throw `TimeoutException` ([#37](https://github.com/microsoft/durabletask-java/issues/37))
+* The `waitForInstanceStart(...)` and `waitForInstanceCompletion(...)` methods of the `DurableTaskClient` interface now throw a checked `TimeoutException`

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Build](https://github.com/microsoft/durabletask-java/actions/workflows/build-validation.yml/badge.svg)](https://github.com/microsoft/durabletask-java/actions/workflows/build-validation.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-⚠ This project is preview quality and not yet ready for production use ⚠
-
 This repo contains the Java SDK for the Durable Task Framework as well as classes and annotations to support running [Azure Durable Functions](https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-overview?tabs=java) for Java. With this SDK, you can define, schedule, and manage durable orchestrations using ordinary Java code.
 
 ### Simple, fault-tolerant sequences

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableOrchestrationTrigger.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/DurableOrchestrationTrigger.java
@@ -23,14 +23,12 @@ import java.lang.annotation.Target;
  * <pre>
  * {@literal @}FunctionName("HelloCities")
  * public String helloCitiesOrchestrator(
- *         {@literal @}DurableOrchestrationTrigger(name = "orchestratorRequestProtoBytes") String orchestratorRequestProtoBytes) {
- *     return OrchestrationRunner.loadAndRun(orchestratorRequestProtoBytes, ctx -{@literal >} {
- *         String result = "";
- *         result += ctx.callActivity("SayHello", "Tokyo", String.class).await() + ", ";
- *         result += ctx.callActivity("SayHello", "London", String.class).await() + ", ";
- *         result += ctx.callActivity("SayHello", "Seattle", String.class).await();
- *         return result;
- *     });
+ *         {@literal @}DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+ *     String result = "";
+ *     result += ctx.callActivity("SayHello", "Tokyo", String.class).await() + ", ";
+ *     result += ctx.callActivity("SayHello", "London", String.class).await() + ", ";
+ *     result += ctx.callActivity("SayHello", "Seattle", String.class).await();
+ *     return result;
  * }
  * </pre>
  * 

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -46,7 +46,7 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
 
             // Need to keep track of this channel so we can dispose it on close()
             this.managedSidecarChannel = ManagedChannelBuilder
-                    .forAddress("127.0.0.1", port)
+                    .forAddress("localhost", port)
                     .usePlaintext()
                     .build();
             sidecarGrpcChannel = this.managedSidecarChannel;

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
@@ -49,7 +49,7 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
 
             // Need to keep track of this channel so we can dispose it on close()
             this.managedSidecarChannel = ManagedChannelBuilder
-                    .forAddress("127.0.0.1", port)
+                    .forAddress("localhost", port)
                     .usePlaintext()
                     .build();
             sidecarGrpcChannel = this.managedSidecarChannel;

--- a/samples-azure-functions/host.json
+++ b/samples-azure-functions/host.json
@@ -17,7 +17,7 @@
     }
   },
   "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"
   }
 }


### PR DESCRIPTION
A few small changes related to the v1.0.0 release.

* Fixed the JavaDoc example code for the `DurableOrchestrationTrigger ` annotation, which was outdated
* Fixed extension bundles version in Azure Functions sample project
* Changed localhost address for client and worker from `127.0.0.1` to `localhost` for better compatibility with hybrid WSL2 setups (an issue I noticed when testing with Dapr)
* Added a few breaking changes to the v1.0.0 release notes

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] (N/A) My changes are added to the `CHANGELOG.md`
* [x] (N/A) I have added all required tests (Unit tests, E2E tests)

### Additional information

The outdated JavaDoc documentation will require an update to Maven so that the JavaDocs on learn.microsoft.com can be correctly updated. I don't think it's super urgent, but we should make this update at a convenient time.