### PR TITLE
Break long timers into smaller timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Support Suspend and Resume Client APIs ([#104](https://github.com/microsoft/durabletask-java/issues/104))
 * Fix the potential NPE issue of `DurableTaskClient terminate` method ([#104](https://github.com/microsoft/durabletask-java/issues/104))
 * Add waitForCompletionOrCreateCheckStatusResponse client API ([#115](https://github.com/microsoft/durabletask-java/pull/115))
-
+* Support long timers by breaking up into smaller timers ([#114](https://github.com/microsoft/durabletask-java/issues/114))
 
 ## v1.0.0
 

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
@@ -11,6 +11,7 @@ import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGr
 
 import io.grpc.*;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -28,6 +29,8 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
 
     private final ManagedChannel managedSidecarChannel;
     private final DataConverter dataConverter;
+    private static final Duration DEFAULT_MAXIMUM_TIMER_INTERVAL = Duration.ofDays(3);
+    private final Duration maximumTimerInterval;
 
     private final TaskHubSidecarServiceBlockingStub sidecarClient;
 
@@ -57,6 +60,7 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
 
         this.sidecarClient = TaskHubSidecarServiceGrpc.newBlockingStub(sidecarGrpcChannel);
         this.dataConverter = builder.dataConverter != null ? builder.dataConverter : new JacksonDataConverter();
+        this.maximumTimerInterval = builder.maximumTimerInterval != null ? builder.maximumTimerInterval : DEFAULT_MAXIMUM_TIMER_INTERVAL;
     }
 
     /**
@@ -108,6 +112,7 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
         TaskOrchestrationExecutor taskOrchestrationExecutor = new TaskOrchestrationExecutor(
                 this.orchestrationFactories,
                 this.dataConverter,
+                this.maximumTimerInterval,
                 logger);
         TaskActivityExecutor taskActivityExecutor = new TaskActivityExecutor(
                 this.activityFactories,

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
@@ -23,13 +23,13 @@ import java.util.logging.Logger;
 public final class DurableTaskGrpcWorker implements AutoCloseable {
     private static final int DEFAULT_PORT = 4001;
     private static final Logger logger = Logger.getLogger(DurableTaskGrpcWorker.class.getPackage().getName());
+    private static final Duration DEFAULT_MAXIMUM_TIMER_INTERVAL = Duration.ofDays(3);
 
     private final HashMap<String, TaskOrchestrationFactory> orchestrationFactories = new HashMap<>();
     private final HashMap<String, TaskActivityFactory> activityFactories = new HashMap<>();
 
     private final ManagedChannel managedSidecarChannel;
     private final DataConverter dataConverter;
-    private static final Duration DEFAULT_MAXIMUM_TIMER_INTERVAL = Duration.ofDays(3);
     private final Duration maximumTimerInterval;
 
     private final TaskHubSidecarServiceBlockingStub sidecarClient;

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerBuilder.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerBuilder.java
@@ -4,6 +4,7 @@ package com.microsoft.durabletask;
 
 import io.grpc.Channel;
 
+import java.time.Duration;
 import java.util.HashMap;
 
 /**
@@ -15,6 +16,7 @@ public final class DurableTaskGrpcWorkerBuilder {
     int port;
     Channel channel;
     DataConverter dataConverter;
+    Duration maximumTimerInterval;
 
     /**
      * Adds an orchestration factory to be used by the constructed {@link DurableTaskGrpcWorker}.
@@ -96,6 +98,17 @@ public final class DurableTaskGrpcWorkerBuilder {
      */
     public DurableTaskGrpcWorkerBuilder dataConverter(DataConverter dataConverter) {
         this.dataConverter = dataConverter;
+        return this;
+    }
+
+    /**
+     * Sets the maximum timer interval. If not specified, the default maximum timer interval duration will be used.
+     *
+     * @param maximumTimerInterval the maximum timer interval
+     * @return this builder object
+     */
+    public DurableTaskGrpcWorkerBuilder maximumTimerInterval(Duration maximumTimerInterval) {
+        this.maximumTimerInterval = maximumTimerInterval;
         return this;
     }
 

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerBuilder.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerBuilder.java
@@ -103,6 +103,7 @@ public final class DurableTaskGrpcWorkerBuilder {
 
     /**
      * Sets the maximum timer interval. If not specified, the default maximum timer interval duration will be used.
+     * The default maximum timer interval duration is 3 days.
      *
      * @param maximumTimerInterval the maximum timer interval
      * @return this builder object

--- a/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
+++ b/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
@@ -6,6 +6,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.StringValue;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
 
+import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.logging.Logger;
@@ -18,6 +19,7 @@ import java.util.logging.Logger;
  */
 public final class OrchestrationRunner {
     private static final Logger logger = Logger.getLogger(OrchestrationRunner.class.getPackage().getName());
+    private static final Duration DEFAULT_MAXIMUM_TIMER_INTERVAL = Duration.ofDays(3);
 
     private OrchestrationRunner() {
     }
@@ -126,6 +128,7 @@ public final class OrchestrationRunner {
         TaskOrchestrationExecutor taskOrchestrationExecutor = new TaskOrchestrationExecutor(
                 orchestrationFactories,
                 new JacksonDataConverter(),
+                DEFAULT_MAXIMUM_TIMER_INTERVAL,
                 logger);
 
         // TODO: Error handling

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -24,13 +24,16 @@ final class TaskOrchestrationExecutor {
     private final HashMap<String, TaskOrchestrationFactory> orchestrationFactories;
     private final DataConverter dataConverter;
     private final Logger logger;
+    private final Duration maximumTimerInterval;
 
     public TaskOrchestrationExecutor(
             HashMap<String, TaskOrchestrationFactory> orchestrationFactories,
             DataConverter dataConverter,
+            Duration maximumTimerInterval,
             Logger logger) {
         this.orchestrationFactories = orchestrationFactories;
         this.dataConverter = dataConverter;
+        this.maximumTimerInterval = maximumTimerInterval;
         this.logger = logger;
     }
 
@@ -77,6 +80,7 @@ final class TaskOrchestrationExecutor {
         private final LinkedList<HistoryEvent> unprocessedEvents = new LinkedList<>();
         private final Queue<HistoryEvent> eventsWhileSuspended = new ArrayDeque<>();
         private final DataConverter dataConverter = TaskOrchestrationExecutor.this.dataConverter;
+        private final Duration maximumTimerInterval = TaskOrchestrationExecutor.this.maximumTimerInterval;
         private final Logger logger = TaskOrchestrationExecutor.this.logger;
         private final OrchestrationHistoryIterator historyEventPlayer;
         private int sequenceNumber;
@@ -547,9 +551,14 @@ final class TaskOrchestrationExecutor {
             Helpers.throwIfOrchestratorComplete(this.isComplete);
             Helpers.throwIfArgumentNull(duration, "duration");
 
-            int id = this.sequenceNumber++;
-            Instant fireAt = this.currentInstant.plus(duration);
-            return createInstantTimer(id, fireAt);
+            Instant finalFireAt = this.currentInstant.plus(duration);
+            Duration remainingTime = Duration.between(finalFireAt, this.currentInstant);
+            while (remainingTime.compareTo(this.maximumTimerInterval) > 0) {
+                Instant nextFireAt = this.currentInstant.plus(this.maximumTimerInterval);
+                createInstantTimer(this.sequenceNumber++, nextFireAt).await();
+                remainingTime = Duration.between(finalFireAt, this.currentInstant);
+            }
+            return createInstantTimer(this.sequenceNumber++, finalFireAt);
         }
 
         @Override

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -547,16 +547,6 @@ final class TaskOrchestrationExecutor {
             }
         }
 
-        private Task<Void> createTimer(Instant finalFireAt) {
-            Duration remainingTime = Duration.between(this.currentInstant, finalFireAt);
-            while (remainingTime.compareTo(this.maximumTimerInterval) > 0) {
-                Instant nextFireAt = this.currentInstant.plus(this.maximumTimerInterval);
-                createInstantTimer(this.sequenceNumber++, nextFireAt).await();
-                remainingTime = Duration.between(this.currentInstant, finalFireAt);
-            }
-            return createInstantTimer(this.sequenceNumber++, finalFireAt);
-        }
-
         public Task<Void> createTimer(Duration duration) {
             Helpers.throwIfOrchestratorComplete(this.isComplete);
             Helpers.throwIfArgumentNull(duration, "duration");
@@ -572,6 +562,16 @@ final class TaskOrchestrationExecutor {
 
             Instant finalFireAt = zonedDateTime.toInstant();
             return createTimer(finalFireAt);
+        }
+
+        private Task<Void> createTimer(Instant finalFireAt) {
+            Duration remainingTime = Duration.between(this.currentInstant, finalFireAt);
+            while (remainingTime.compareTo(this.maximumTimerInterval) > 0) {
+                Instant nextFireAt = this.currentInstant.plus(this.maximumTimerInterval);
+                createInstantTimer(this.sequenceNumber++, nextFireAt).await();
+                remainingTime = Duration.between(this.currentInstant, finalFireAt);
+            }
+            return createInstantTimer(this.sequenceNumber++, finalFireAt);
         }
 
         private Task<Void> createInstantTimer(int id, Instant fireAt) {

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTestBase.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTestBase.java
@@ -38,6 +38,11 @@ public class IntegrationTestBase {
             return server;
         }
 
+        public TestDurableTaskWorkerBuilder setMaximumTimerInterval(Duration maximumTimerInterval) {
+            this.innerBuilder.maximumTimerInterval(maximumTimerInterval);
+            return this;
+        }
+
         public TestDurableTaskWorkerBuilder addOrchestrator(
                 String name,
                 TaskOrchestration implementation) {


### PR DESCRIPTION
### Issue describing the changes in this PR

Resolves #114 
Currently, we do not support timers longer than 7 days. However, the changes in this PR work around that by breaking up a single long timer into several shorter ones.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)
