### PR TITLE
Support restartInstance and add restartPostUri in HttpManagementPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix the potential NPE issue of `DurableTaskClient terminate` method ([#104](https://github.com/microsoft/durabletask-java/issues/104))
 * Add waitForCompletionOrCreateCheckStatusResponse client API ([#115](https://github.com/microsoft/durabletask-java/pull/115))
 * Support long timers by breaking up into smaller timers ([#114](https://github.com/microsoft/durabletask-java/issues/114))
+* Support restartInstance and pass restartPostUri in HttpManagementPayload ([#108](https://github.com/microsoft/durabletask-java/issues/108))
 
 ## v1.0.0
 

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/HttpManagementPayload.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/HttpManagementPayload.java
@@ -13,10 +13,8 @@ public class HttpManagementPayload {
     private final String id;
     private final String purgeHistoryDeleteUri;
     private final String restartPostUri;
-    private final String resumePostUri;
     private final String sendEventPostUri;
     private final String statusQueryGetUri;
-    private final String suspendPostUri;
     private final String terminatePostUri;
 
     /**
@@ -33,10 +31,8 @@ public class HttpManagementPayload {
         this.id = instanceId;
         this.purgeHistoryDeleteUri = instanceStatusURL + "?" + requiredQueryStringParameters;
         this.restartPostUri = instanceStatusURL + "/restart?" + requiredQueryStringParameters;
-        this.resumePostUri = instanceStatusURL + "/resume?reason={text}&" +  requiredQueryStringParameters;
         this.sendEventPostUri = instanceStatusURL + "/raiseEvent/{eventName}?" + requiredQueryStringParameters;
         this.statusQueryGetUri = instanceStatusURL + "?" + requiredQueryStringParameters;
-        this.suspendPostUri = instanceStatusURL + "/suspend?reason={text}&" + requiredQueryStringParameters;
         this.terminatePostUri = instanceStatusURL + "/terminate?reason={text}&" + requiredQueryStringParameters;
     }
 
@@ -94,21 +90,4 @@ public class HttpManagementPayload {
         return restartPostUri;
     }
 
-    /**
-     * Gets the HTTP POST instance resume endpoint.
-     *
-     * @return The HTTP URL for posting instance resume commands.
-     */
-    public String getResumePostUri() {
-        return resumePostUri;
-    }
-
-    /**
-     * Gets the HTTP POST instance suspend endpoint.
-     *
-     * @return The HTTP URL for posting instance suspend commands.
-     */
-    public String getSuspendPostUri() {
-        return suspendPostUri;
-    }
 }

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/HttpManagementPayload.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/HttpManagementPayload.java
@@ -12,8 +12,11 @@ package com.microsoft.durabletask.azurefunctions;
 public class HttpManagementPayload {
     private final String id;
     private final String purgeHistoryDeleteUri;
+    private final String restartPostUri;
+    private final String resumePostUri;
     private final String sendEventPostUri;
     private final String statusQueryGetUri;
+    private final String suspendPostUri;
     private final String terminatePostUri;
 
     /**
@@ -29,8 +32,11 @@ public class HttpManagementPayload {
             String requiredQueryStringParameters) {
         this.id = instanceId;
         this.purgeHistoryDeleteUri = instanceStatusURL + "?" + requiredQueryStringParameters;
+        this.restartPostUri = instanceStatusURL + "/restart?" + requiredQueryStringParameters;
+        this.resumePostUri = instanceStatusURL + "/resume?reason={text}&" +  requiredQueryStringParameters;
         this.sendEventPostUri = instanceStatusURL + "/raiseEvent/{eventName}?" + requiredQueryStringParameters;
         this.statusQueryGetUri = instanceStatusURL + "?" + requiredQueryStringParameters;
+        this.suspendPostUri = instanceStatusURL + "/suspend?reason={text}&" + requiredQueryStringParameters;
         this.terminatePostUri = instanceStatusURL + "/terminate?reason={text}&" + requiredQueryStringParameters;
     }
 
@@ -77,5 +83,32 @@ public class HttpManagementPayload {
      */
     public String getPurgeHistoryDeleteUri() {
         return this.purgeHistoryDeleteUri;
+    }
+
+    /**
+     * Gets the HTTP POST instance restart endpoint.
+     *
+     * @return The HTTP URL for posting instance restart commands.
+     */
+    public String getRestartPostUri() {
+        return restartPostUri;
+    }
+
+    /**
+     * Gets the HTTP POST instance resume endpoint.
+     *
+     * @return The HTTP URL for posting instance resume commands.
+     */
+    public String getResumePostUri() {
+        return resumePostUri;
+    }
+
+    /**
+     * Gets the HTTP POST instance suspend endpoint.
+     *
+     * @return The HTTP URL for posting instance suspend commands.
+     */
+    public String getSuspendPostUri() {
+        return suspendPostUri;
     }
 }

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -311,4 +311,6 @@ public abstract class DurableTaskClient implements AutoCloseable {
      * @param reason the reason for resuming the orchestration instance
      */
     public abstract void resumeInstance(String instanceId, @Nullable String reason);
+
+    public abstract String restartInstance(String instanceId, boolean restartWithNewInstanceId);
 }

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -312,5 +312,13 @@ public abstract class DurableTaskClient implements AutoCloseable {
      */
     public abstract void resumeInstance(String instanceId, @Nullable String reason);
 
+    /**
+     * Restarts an existing orchestration instance with the original input.
+     * @param instanceId the ID of the previously run orchestration instance to restart.
+     * @param restartWithNewInstanceId <code>true</code> to restart the orchestration instance with a new instance ID
+     *                                 <code>false</code> to restart the orchestration instance with same instance ID
+     * @return the ID of the scheduled orchestration instance, which is either <code>instanceId</code> or randomly
+     *         generated depending on the value of <code>restartWithNewInstanceId</code>
+     */
     public abstract String restartInstance(String instanceId, boolean restartWithNewInstanceId);
 }

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -303,6 +303,24 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
         this.sidecarClient.resumeInstance(resumeRequestBuilder.build());
     }
 
+    @Override
+    public String restartInstance(String instanceId, boolean restartWithNewInstanceId) {
+        OrchestrationMetadata metadata = this.getInstanceMetadata(instanceId, true);
+        if (!metadata.isInstanceFound()) {
+            throw new IllegalArgumentException(new StringBuilder()
+                    .append("An orchestration with instanceId ")
+                    .append(instanceId)
+                    .append(" was not found.").toString());
+        }
+
+        if (restartWithNewInstanceId) {
+            return this.scheduleNewOrchestrationInstance(metadata.getName(), this.dataConverter.deserialize(metadata.getSerializedInput(), Object.class));
+        }
+        else {
+            return this.scheduleNewOrchestrationInstance(metadata.getName(), this.dataConverter.deserialize(metadata.getSerializedInput(), Object.class), metadata.getInstanceId());
+        }
+    }
+
     private PurgeResult toPurgeResult(PurgeInstancesResponse response){
         return new PurgeResult(response.getDeletedInstanceCount());
     }

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -447,7 +447,7 @@ public class IntegrationTests extends IntegrationTestBase {
 
         DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
         try (worker; client) {
-            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName, "RestartTest");
+            client.scheduleNewOrchestrationInstance(orchestratorName, "RestartTest");
 
             assertThrows(
                 IllegalArgumentException.class,

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -5,6 +5,8 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.post;
@@ -26,14 +28,7 @@ public class EndToEndTests {
         Response response = post(startOrchestrationPath);
         JsonPath jsonPath = response.jsonPath();
         String statusQueryGetUri = jsonPath.get("statusQueryGetUri");
-        String runTimeStatus = null;
-        for (int i = 0; i < 15; i++) {
-            Response statusResponse = get(statusQueryGetUri);
-            runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
-            if (!"Completed".equals(runTimeStatus)) {
-                Thread.sleep(1000);
-            } else break;
-        }
+        String runTimeStatus = waitForCompletion(statusQueryGetUri);
         assertEquals("Completed", runTimeStatus);
     }
 
@@ -59,4 +54,44 @@ public class EndToEndTests {
         runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
         assertEquals("Terminated", runTimeStatus);
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void restart(boolean restartWithNewInstanceId) throws InterruptedException {
+        String startOrchestrationPath = "/api/StartOrchestration";
+        Response response = post(startOrchestrationPath);
+        JsonPath jsonPath = response.jsonPath();
+        String statusQueryGetUri = jsonPath.get("statusQueryGetUri");
+        String runTimeStatus = waitForCompletion(statusQueryGetUri);
+        assertEquals("Completed", runTimeStatus);
+        Response statusResponse = get(statusQueryGetUri);
+        String instanceId = statusResponse.jsonPath().get("instanceId");
+
+        String restartPostUri = jsonPath.get("restartPostUri") + "&restartWithNewInstanceId=" + restartWithNewInstanceId;
+        Response restartResponse = post(restartPostUri);
+        JsonPath restartJsonPath = restartResponse.jsonPath();
+        String restartStatusQueryGetUri = restartJsonPath.get("statusQueryGetUri");
+        String restartRuntimeStatus = waitForCompletion(restartStatusQueryGetUri);
+        assertEquals("Completed", restartRuntimeStatus);
+        Response restartStatusResponse = get(restartStatusQueryGetUri);
+        String newInstanceId = restartStatusResponse.jsonPath().get("instanceId");
+        if (restartWithNewInstanceId) {
+            assertNotEquals(instanceId, newInstanceId);
+        } else {
+            assertEquals(instanceId, newInstanceId);
+        }
+    }
+
+    private String waitForCompletion(String statusQueryGetUri) throws InterruptedException {
+        String runTimeStatus = null;
+        for (int i = 0; i < 15; i++) {
+            Response statusResponse = get(statusQueryGetUri);
+            runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
+            if (!"Completed".equals(runTimeStatus)) {
+                Thread.sleep(1000);
+            } else break;
+        }
+        return runTimeStatus;
+    }
+
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves #108 
With these changes, we now support restartInstance and we pass the restartPostUri, resumePostUri and suspendPostUri values in the HttpManagementPayload

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
    * [x] Create issue https://github.com/microsoft/durabletask-java/issues/105 to track document update
* [x] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)
