### PR TITLE
Fix orchestrator has already completed issue

### DIFF
--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -55,7 +55,7 @@ final class TaskOrchestrationExecutor {
             context.fail(new FailureDetails(e));
         }
 
-        if (context.continuedAsNew || (completed && context.pendingActions.isEmpty() && !context.waitingForEvents())) {
+        if ((context.continuedAsNew && !context.isComplete) || (completed && context.pendingActions.isEmpty() && !context.waitingForEvents())) {
             // There are no further actions for the orchestrator to take so auto-complete the orchestration.
             context.complete(null);
         }

--- a/samples-azure-functions/src/main/java/com/functions/ContinueAsNew.java
+++ b/samples-azure-functions/src/main/java/com/functions/ContinueAsNew.java
@@ -1,0 +1,40 @@
+package com.functions;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.TaskOrchestrationContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientInput;
+import com.microsoft.durabletask.azurefunctions.DurableOrchestrationTrigger;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public class ContinueAsNew {
+    @FunctionName("ContinueAsNew")
+    public HttpResponseMessage continueAsNew(
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        DurableTaskClient client = durableContext.getClient();
+        String instanceId = client.scheduleNewOrchestrationInstance("EternalOrchestrator");
+        context.getLogger().info("Created new Java orchestration with instance ID = " + instanceId);
+        return durableContext.createCheckStatusResponse(request, instanceId);
+    }
+
+    @FunctionName("EternalOrchestrator")
+    public void eternalOrchestrator(@DurableOrchestrationTrigger(name = "runtimeState") TaskOrchestrationContext ctx)
+    {
+        System.out.println("Processing stuff...");
+        ctx.createTimer(Duration.ofSeconds(2)).await();
+        ctx.continueAsNew(null);
+    }
+}

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -49,7 +49,7 @@ public class EndToEndTests {
         for (int i = 0; i < 10; i++) {
             Response statusResponse = get(statusQueryGetUri);
             runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
-            assertEquals("Completed", runTimeStatus);
+            assertEquals("Running", runTimeStatus);
             Thread.sleep(1000);
         }
     }

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -52,8 +52,9 @@ public class EndToEndTests {
             assertEquals("Running", runTimeStatus);
             Thread.sleep(1000);
         }
-        Object terminatePostUri = jsonPath.get("terminatePostUri");
-        post(terminatePostUri.toString());
+        String terminatePostUri = jsonPath.get("terminatePostUri");
+        post(terminatePostUri, "Terminated the test");
+        Thread.sleep(1000);
         Response statusResponse = get(statusQueryGetUri);
         runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
         assertEquals("Terminated", runTimeStatus);

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -52,5 +52,10 @@ public class EndToEndTests {
             assertEquals("Running", runTimeStatus);
             Thread.sleep(1000);
         }
+        Object terminatePostUri = jsonPath.get("terminatePostUri");
+        post(terminatePostUri.toString());
+        Response statusResponse = get(statusQueryGetUri);
+        runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
+        assertEquals("Terminated", runTimeStatus);
     }
 }

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -12,17 +12,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("e2e")
 public class EndToEndTests {
-    private static final String hostHealthPingPath = "/admin/host/ping";
-    private static final String startOrchestrationPath = "/api/StartOrchestration";
 
     @Order(1)
     @Test
     public void setupHost() {
+        String hostHealthPingPath = "/admin/host/ping";
         post(hostHealthPingPath).then().statusCode(200);
     }
 
     @Test
     public void basicChain() throws InterruptedException {
+        String startOrchestrationPath = "/api/StartOrchestration";
         Response response = post(startOrchestrationPath);
         JsonPath jsonPath = response.jsonPath();
         String statusQueryGetUri = jsonPath.get("statusQueryGetUri");
@@ -35,5 +35,22 @@ public class EndToEndTests {
             } else break;
         }
         assertEquals("Completed", runTimeStatus);
+    }
+
+
+    @Test
+    public void continueAsNew() throws InterruptedException {
+        String startOrchestrationPath = "api/ContinueAsNew";
+        Response response = post(startOrchestrationPath);
+        JsonPath jsonPath = response.jsonPath();
+        String statusQueryGetUri = jsonPath.get("statusQueryGetUri");
+        String runTimeStatus;
+        //assert that the orchestration is always running.
+        for (int i = 0; i < 10; i++) {
+            Response statusResponse = get(statusQueryGetUri);
+            runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
+            assertEquals("Completed", runTimeStatus);
+            Thread.sleep(1000);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [138](https://github.com/microsoft/durabletask-java/issues/138)

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information


For a sample orchestration function 
```java
    @FunctionName("EternalOrchestrator")
    public void startWorkflowSchedule(@DurableOrchestrationTrigger(name = "runtimeState") TaskOrchestrationContext ctx) 
     {
        LOGGER.info("Doing something in the cleanup loop");

        ctx.createTimer(Duration.ofSeconds(60)).await();

        ctx.continueAsNew(null);
     }
```

The invocation process complete twice:
1. First time at https://github.com/microsoft/durabletask-java/blob/4a204cd238849d183581f7b73bcf86691ce97436/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java#L66 `ctx.complete(null)`
2. Second time at https://github.com/microsoft/durabletask-java/blob/4a204cd238849d183581f7b73bcf86691ce97436/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L60
This is the one causing exception as `isCompleted` flag is already set to true at the first complete. 

Update the condition check at 2 to avoid repeating `complete`. 
