### PR TITLE
enable resume and suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.2.0
-* Add `thenAccept` and `thenApply` to `Task` interface ([#148](https://github.com/microsoft/durabletask-java/pull/148)) 
-
+* Add `thenAccept` and `thenApply` to `Task` interface ([#148](https://github.com/microsoft/durabletask-java/pull/148))
+* Support Suspend and Resume Client APIs ([#104](https://github.com/microsoft/durabletask-java/issues/104))
+* Support restartInstance and pass restartPostUri in HttpManagementPayload ([#108](https://github.com/microsoft/durabletask-java/issues/108))
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.2.0
 * Add `thenAccept` and `thenApply` to `Task` interface ([#148](https://github.com/microsoft/durabletask-java/pull/148))
-* Support Suspend and Resume Client APIs ([#104](https://github.com/microsoft/durabletask-java/issues/104))
+* Support Suspend and Resume Client APIs ([#151](https://github.com/microsoft/durabletask-java/pull/151))
 * Support restartInstance and pass restartPostUri in HttpManagementPayload ([#108](https://github.com/microsoft/durabletask-java/issues/108))
 
 ## v1.1.1

--- a/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/HttpManagementPayload.java
+++ b/azurefunctions/src/main/java/com/microsoft/durabletask/azurefunctions/HttpManagementPayload.java
@@ -16,6 +16,8 @@ public class HttpManagementPayload {
     private final String sendEventPostUri;
     private final String statusQueryGetUri;
     private final String terminatePostUri;
+    private final String resumePostUri;
+    private final String suspendPostUri;
 
     /**
      * Creates a {@link HttpManagementPayload} to manage orchestration instances
@@ -34,6 +36,8 @@ public class HttpManagementPayload {
         this.sendEventPostUri = instanceStatusURL + "/raiseEvent/{eventName}?" + requiredQueryStringParameters;
         this.statusQueryGetUri = instanceStatusURL + "?" + requiredQueryStringParameters;
         this.terminatePostUri = instanceStatusURL + "/terminate?reason={text}&" + requiredQueryStringParameters;
+        this.resumePostUri = instanceStatusURL + "/resume?reason={text}&" + requiredQueryStringParameters;
+        this.suspendPostUri = instanceStatusURL + "/suspend?reason={text}&" + requiredQueryStringParameters;
     }
 
     /**

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -292,33 +292,33 @@ public abstract class DurableTaskClient implements AutoCloseable {
      */
     public abstract String restartInstance(String instanceId, boolean restartWithNewInstanceId);
 
-//    /**
-//     * Suspends a running orchestration instance.
-//     * @param instanceId the ID of the orchestration instance to suspend
-//     */
-//    public void suspendInstance (String instanceId) {
-//        this.suspendInstance(instanceId, null);
-//    }
-//
-//    /**
-//     * Resumes a running orchestration instance.
-//     * @param instanceId the ID of the orchestration instance to resume
-//     */
-//    public void resumeInstance(String instanceId) {
-//        this.resumeInstance(instanceId, null);
-//    }
-//
-//    /**
-//     * Suspends a running orchestration instance.
-//     * @param instanceId the ID of the orchestration instance to suspend
-//     * @param reason the reason for suspending the orchestration instance
-//     */
-//    public abstract void suspendInstance(String instanceId, @Nullable String reason);
-//
-//    /**
-//     * Resumes a running orchestration instance.
-//     * @param instanceId the ID of the orchestration instance to resume
-//     * @param reason the reason for resuming the orchestration instance
-//     */
-//    public abstract void resumeInstance(String instanceId, @Nullable String reason);
+    /**
+     * Suspends a running orchestration instance.
+     * @param instanceId the ID of the orchestration instance to suspend
+     */
+    public void suspendInstance (String instanceId) {
+        this.suspendInstance(instanceId, null);
+    }
+
+    /**
+     * Resumes a running orchestration instance.
+     * @param instanceId the ID of the orchestration instance to resume
+     */
+    public void resumeInstance(String instanceId) {
+        this.resumeInstance(instanceId, null);
+    }
+
+    /**
+     * Suspends a running orchestration instance.
+     * @param instanceId the ID of the orchestration instance to suspend
+     * @param reason the reason for suspending the orchestration instance
+     */
+    public abstract void suspendInstance(String instanceId, @Nullable String reason);
+
+    /**
+     * Resumes a running orchestration instance.
+     * @param instanceId the ID of the orchestration instance to resume
+     * @param reason the reason for resuming the orchestration instance
+     */
+    public abstract void resumeInstance(String instanceId, @Nullable String reason);
 }

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -283,25 +283,25 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
         }
     }
 
-//    @Override
-//    public void suspendInstance(String instanceId, @Nullable String reason) {
-//        SuspendRequest.Builder suspendRequestBuilder = SuspendRequest.newBuilder();
-//        suspendRequestBuilder.setInstanceId(instanceId);
-//        if (reason != null) {
-//            suspendRequestBuilder.setReason(StringValue.of(reason));
-//        }
-//        this.sidecarClient.suspendInstance(suspendRequestBuilder.build());
-//    }
-//
-//    @Override
-//    public void resumeInstance(String instanceId, @Nullable String reason) {
-//        ResumeRequest.Builder resumeRequestBuilder = ResumeRequest.newBuilder();
-//        resumeRequestBuilder.setInstanceId(instanceId);
-//        if (reason != null) {
-//            resumeRequestBuilder.setReason(StringValue.of(reason));
-//        }
-//        this.sidecarClient.resumeInstance(resumeRequestBuilder.build());
-//    }
+    @Override
+    public void suspendInstance(String instanceId, @Nullable String reason) {
+        SuspendRequest.Builder suspendRequestBuilder = SuspendRequest.newBuilder();
+        suspendRequestBuilder.setInstanceId(instanceId);
+        if (reason != null) {
+            suspendRequestBuilder.setReason(StringValue.of(reason));
+        }
+        this.sidecarClient.suspendInstance(suspendRequestBuilder.build());
+    }
+
+    @Override
+    public void resumeInstance(String instanceId, @Nullable String reason) {
+        ResumeRequest.Builder resumeRequestBuilder = ResumeRequest.newBuilder();
+        resumeRequestBuilder.setInstanceId(instanceId);
+        if (reason != null) {
+            resumeRequestBuilder.setReason(StringValue.of(reason));
+        }
+        this.sidecarClient.resumeInstance(resumeRequestBuilder.build());
+    }
 
     @Override
     public String restartInstance(String instanceId, boolean restartWithNewInstanceId) {

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -457,71 +457,71 @@ public class IntegrationTests extends IntegrationTestBase {
 
     }
 
-//    @Test
-//    void suspendResumeOrchestration() throws TimeoutException, InterruptedException {
-//        final String orchestratorName = "suspend";
-//        final String eventName = "MyEvent";
-//        final String eventPayload = "testPayload";
-//        final Duration suspendTimeout = Duration.ofSeconds(5);
-//
-//        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
-//                .addOrchestrator(orchestratorName, ctx -> {
-//                    String payload = ctx.waitForExternalEvent(eventName, String.class).await();
-//                    ctx.complete(payload);
-//                })
-//                .buildAndStart();
-//
-//        DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
-//        try (worker; client) {
-//            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName);
-//            client.suspendInstance(instanceId);
-//            OrchestrationMetadata instance = client.waitForInstanceStart(instanceId, defaultTimeout);
-//            assertNotNull(instance);
-//            assertEquals(OrchestrationRuntimeStatus.SUSPENDED, instance.getRuntimeStatus());
-//
-//            client.raiseEvent(instanceId, eventName, eventPayload);
-//
-//            assertThrows(
-//                    TimeoutException.class,
-//                    () -> client.waitForInstanceCompletion(instanceId, suspendTimeout, false),
-//                    "Expected to throw TimeoutException, but it didn't"
-//                    );
-//
-//            String resumeReason = "Resume for testing.";
-//            client.resumeInstance(instanceId, resumeReason);
-//            instance = client.waitForInstanceCompletion(instanceId, defaultTimeout, true);
-//            assertNotNull(instance);
-//            assertEquals(instanceId, instance.getInstanceId());
-//            assertEquals(eventPayload, instance.readOutputAs(String.class));
-//            assertEquals(OrchestrationRuntimeStatus.COMPLETED, instance.getRuntimeStatus());
-//        }
-//    }
-//
-//    @Test
-//    void terminateSuspendOrchestration() throws TimeoutException, InterruptedException {
-//        final String orchestratorName = "suspendResume";
-//        final String eventName = "MyEvent";
-//        final String eventPayload = "testPayload";
-//
-//        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
-//                .addOrchestrator(orchestratorName, ctx -> {
-//                    String payload = ctx.waitForExternalEvent(eventName, String.class).await();
-//                    ctx.complete(payload);
-//                })
-//                .buildAndStart();
-//
-//        DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
-//        try (worker; client) {
-//            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName);
-//            String suspendReason = "Suspend for testing.";
-//            client.suspendInstance(instanceId, suspendReason);
-//            client.terminate(instanceId, null);
-//            OrchestrationMetadata instance = client.waitForInstanceCompletion(instanceId, defaultTimeout, false);
-//            assertNotNull(instance);
-//            assertEquals(instanceId, instance.getInstanceId());
-//            assertEquals(OrchestrationRuntimeStatus.TERMINATED, instance.getRuntimeStatus());
-//        }
-//    }
+    @Test
+    void suspendResumeOrchestration() throws TimeoutException, InterruptedException {
+        final String orchestratorName = "suspend";
+        final String eventName = "MyEvent";
+        final String eventPayload = "testPayload";
+        final Duration suspendTimeout = Duration.ofSeconds(5);
+
+        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
+                .addOrchestrator(orchestratorName, ctx -> {
+                    String payload = ctx.waitForExternalEvent(eventName, String.class).await();
+                    ctx.complete(payload);
+                })
+                .buildAndStart();
+
+        DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
+        try (worker; client) {
+            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName);
+            client.suspendInstance(instanceId);
+            OrchestrationMetadata instance = client.waitForInstanceStart(instanceId, defaultTimeout);
+            assertNotNull(instance);
+            assertEquals(OrchestrationRuntimeStatus.SUSPENDED, instance.getRuntimeStatus());
+
+            client.raiseEvent(instanceId, eventName, eventPayload);
+
+            assertThrows(
+                    TimeoutException.class,
+                    () -> client.waitForInstanceCompletion(instanceId, suspendTimeout, false),
+                    "Expected to throw TimeoutException, but it didn't"
+                    );
+
+            String resumeReason = "Resume for testing.";
+            client.resumeInstance(instanceId, resumeReason);
+            instance = client.waitForInstanceCompletion(instanceId, defaultTimeout, true);
+            assertNotNull(instance);
+            assertEquals(instanceId, instance.getInstanceId());
+            assertEquals(eventPayload, instance.readOutputAs(String.class));
+            assertEquals(OrchestrationRuntimeStatus.COMPLETED, instance.getRuntimeStatus());
+        }
+    }
+
+    @Test
+    void terminateSuspendOrchestration() throws TimeoutException, InterruptedException {
+        final String orchestratorName = "suspendResume";
+        final String eventName = "MyEvent";
+        final String eventPayload = "testPayload";
+
+        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
+                .addOrchestrator(orchestratorName, ctx -> {
+                    String payload = ctx.waitForExternalEvent(eventName, String.class).await();
+                    ctx.complete(payload);
+                })
+                .buildAndStart();
+
+        DurableTaskClient client = new DurableTaskGrpcClientBuilder().build();
+        try (worker; client) {
+            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName);
+            String suspendReason = "Suspend for testing.";
+            client.suspendInstance(instanceId, suspendReason);
+            client.terminate(instanceId, null);
+            OrchestrationMetadata instance = client.waitForInstanceCompletion(instanceId, defaultTimeout, false);
+            assertNotNull(instance);
+            assertEquals(instanceId, instance.getInstanceId());
+            assertEquals(OrchestrationRuntimeStatus.TERMINATED, instance.getRuntimeStatus());
+        }
+    }
 
     @Test
     void activityFanOut() throws IOException, TimeoutException {

--- a/samples-azure-functions/src/main/java/com/functions/ResumeSuspend.java
+++ b/samples-azure-functions/src/main/java/com/functions/ResumeSuspend.java
@@ -1,0 +1,39 @@
+package com.functions;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.TaskOrchestrationContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientInput;
+import com.microsoft.durabletask.azurefunctions.DurableOrchestrationTrigger;
+
+import java.util.Optional;
+
+public class ResumeSuspend {
+
+    @FunctionName("StartResumeSuspendOrchestration")
+    public HttpResponseMessage startResumeSuspendOrchestration(
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        DurableTaskClient client = durableContext.getClient();
+        String instanceId = client.scheduleNewOrchestrationInstance("ResumeSuspend");
+        context.getLogger().info("Created new Java orchestration with instance ID = " + instanceId);
+        return durableContext.createCheckStatusResponse(request, instanceId);
+    }
+
+    @FunctionName("ResumeSuspend")
+    public void resumeSuspend(
+            @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+        ctx.waitForExternalEvent("test").await();
+        return;
+    }
+}

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -1,5 +1,7 @@
 package com.functions;
 
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Order;
@@ -124,7 +126,15 @@ public class EndToEndTests {
 
         String sendEventPostUri = jsonPath.get("sendEventPostUri");
         sendEventPostUri = sendEventPostUri.replace("{eventName}", "test");
-        post(sendEventPostUri);
+
+        String requestBody = "{\"value\":\"Test\"}";
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON) // Set the request content type
+                .body(requestBody) // Set the request body
+                .post(sendEventPostUri)
+                .then()
+                .statusCode(202);
 
         boolean suspendAfterEventSent = pollingCheck(statusQueryGetUri, "Suspended", null, Duration.ofSeconds(5));
         assertTrue(suspendAfterEventSent);
@@ -146,7 +156,6 @@ public class EndToEndTests {
         while (Duration.between(begin, runningTime).compareTo(timeout) <= 0) {
             Response statusResponse = get(statusQueryGetUri);
             runTimeStatus = statusResponse.jsonPath().get("runtimeStatus");
-            System.out.println(runTimeStatus);
             if (expectedState.equals(runTimeStatus)) {
                 return true;
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Support resuming and suspending orchestration. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [X] Otherwise: [Documentation issue](https://github.com/microsoft/durabletask-java/issues/105) linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information

Test on local works fine with DF extension 2.9.3, right now the fully released extension build is 4.4.0 which contains DF extension 2.9.2. Waiting for the next extension bundle fully released then this PR should succeed on CI and can be merged. 