### PR TITLE
Fix log pipeline - populate logs into kusto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## placeholder
+* Update sdk loggin logics so all level logs are recored into kusto. ([#167](https://github.com/microsoft/durabletask-java/pull/167))
+
 ## v1.4.0
 
 ### Updates

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
@@ -9,6 +9,7 @@ import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.*;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.WorkItem.RequestCase;
 import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc.*;
 
+import com.microsoft.durabletask.log.LoggerManager;
 import io.grpc.*;
 
 import java.time.Duration;
@@ -22,7 +23,7 @@ import java.util.logging.Logger;
  */
 public final class DurableTaskGrpcWorker implements AutoCloseable {
     private static final int DEFAULT_PORT = 4001;
-    private static final Logger logger = Logger.getLogger(DurableTaskGrpcWorker.class.getPackage().getName());
+    private static final Logger logger = LoggerManager.getLogger();
     private static final Duration DEFAULT_MAXIMUM_TIMER_INTERVAL = Duration.ofDays(3);
 
     private final HashMap<String, TaskOrchestrationFactory> orchestrationFactories = new HashMap<>();

--- a/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
+++ b/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
@@ -5,6 +5,7 @@ package com.microsoft.durabletask;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.StringValue;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
+import com.microsoft.durabletask.log.LoggerManager;
 
 import java.time.Duration;
 import java.util.Base64;
@@ -18,7 +19,7 @@ import java.util.logging.Logger;
  * caller must provide orchestration state as serialized protobuf bytes.
  */
 public final class OrchestrationRunner {
-    private static final Logger logger = Logger.getLogger(OrchestrationRunner.class.getPackage().getName());
+    private static final Logger logger = LoggerManager.getLogger();
     private static final Duration DEFAULT_MAXIMUM_TIMER_INTERVAL = Duration.ofDays(3);
 
     private OrchestrationRunner() {

--- a/client/src/main/java/com/microsoft/durabletask/log/FunctionKustoHandler.java
+++ b/client/src/main/java/com/microsoft/durabletask/log/FunctionKustoHandler.java
@@ -1,0 +1,37 @@
+package com.microsoft.durabletask.log;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+class FunctionKustoHandler extends Handler {
+    private static final String FUNCTIONSKUSTOPREFIX = "LanguageWorkerConsoleLog";
+    private static final String DURABLEPREFIX = "DURABLE_JAVA_SDK";
+    @Override
+    public void publish(LogRecord record) {
+        if (record != null && record.getLevel() != null) {
+            PrintStream output = record.getLevel().intValue() <= Level.INFO.intValue() ? System.out : System.err;
+            output.printf("%s%s [%s] {%s.%s}: %s%n",
+                    FUNCTIONSKUSTOPREFIX,
+                    DURABLEPREFIX,
+                    record.getLevel(),
+                    record.getSourceClassName(),
+                    record.getSourceMethodName(),
+                    record.getMessage());
+            if (record.getThrown() != null) {
+                output.printf("%s%s%s%n", FUNCTIONSKUSTOPREFIX, DURABLEPREFIX, Arrays.toString(record.getThrown().getStackTrace()));
+            }
+        }
+    }
+
+    @Override
+    public void flush() {
+        System.out.flush();
+        System.err.flush();
+    }
+
+    @Override
+    public void close() throws SecurityException { }
+}

--- a/client/src/main/java/com/microsoft/durabletask/log/LoggerManager.java
+++ b/client/src/main/java/com/microsoft/durabletask/log/LoggerManager.java
@@ -1,0 +1,35 @@
+package com.microsoft.durabletask.log;
+
+import java.util.Arrays;
+import java.util.logging.*;
+
+public class LoggerManager {
+    private static final Logger logger = initLogger();
+
+    private static Logger initLogger() {
+        Logger logger = Logger.getAnonymousLogger();
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.ALL);
+        logger.addHandler(new FunctionKustoHandler());
+        return logger;
+    }
+
+    public static void setHandler(Handler handler) {
+        clearHandler();
+        addHandler(handler);
+    }
+
+    public static void addHandler(Handler handler) {
+        logger.addHandler(handler);
+    }
+
+    private static void clearHandler() {
+        for (Handler handler : logger.getHandlers()) {
+            logger.removeHandler(handler);
+        }
+    }
+
+    public static Logger getLogger() {
+        return logger;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/log/LoggerManager.java
+++ b/client/src/main/java/com/microsoft/durabletask/log/LoggerManager.java
@@ -1,6 +1,5 @@
 package com.microsoft.durabletask.log;
 
-import java.util.Arrays;
 import java.util.logging.*;
 
 public class LoggerManager {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
With the current logging logic in the SDK, the logs are not recorded anywhere, causing the logs in the SDK to be meaningless. 

This PR updates the current Java Util Logger with `FunctionKustoHandler`, a customized `java.util.logging.Handler` that will stream the logs into kusto table. The picture below shows an example. 
<img width="1431" alt="image" src="https://github.com/microsoft/durabletask-java/assets/89094811/4e6ec325-d4cc-4ae4-afb2-20dd135d50b2">



### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information