### PR TITLE
Fix the exception type for using retriable task in `allOf` method

### DIFF
--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -1134,7 +1134,7 @@ final class TaskOrchestrationExecutor {
                     this.getChildTask().await();
                 } catch (OrchestratorBlockedException ex) {
                     throw ex;
-                } catch (Exception ignored) {
+                } catch (Exception exception) {
                     /**
                      * If this RetriableTask is not configured as part of an allOf method (CompoundTask),
                      * it throws an exception, marking the orchestration as failed. However, if this RetriableTask
@@ -1142,7 +1142,7 @@ final class TaskOrchestrationExecutor {
                      * This approach ensures that when awaiting the future of the allOf method,
                      * it throws the CompositeTaskFailedException defined in its exceptionPath.
                      */
-                    if (!this.isInCompoundTask) throw ignored;
+                    if (!this.isInCompoundTask) throw exception;
                 }
                 return null;
             }

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -1131,7 +1131,7 @@ final class TaskOrchestrationExecutor {
                 // Therefore, once we return from the following `await`,
                 // we just need to await again on the *current* child task to obtain the result of this task
                 try{
-                    this.getChildTask().await();
+                    return this.getChildTask().await();
                 } catch (OrchestratorBlockedException ex) {
                     throw ex;
                 } catch (Exception exception) {

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -1131,9 +1131,17 @@ final class TaskOrchestrationExecutor {
                 // Therefore, once we return from the following `await`,
                 // we just need to await again on the *current* child task to obtain the result of this task
                 try{
-                    return this.getChildTask().await();
+                    this.getChildTask().await();
                 } catch (OrchestratorBlockedException ex) {
                     throw ex;
+                } catch (Exception ignore) {
+                    // ignore the exception from previous child tasks.
+                    // Only needs to return result from the last child task, which is on next line.
+                }
+
+                try {
+                    // Always return the last child task result.
+                    return this.getChildTask().await();
                 } catch (Exception exception) {
                     /**
                      * If this RetriableTask is not configured as part of an allOf method (CompoundTask),

--- a/samples-azure-functions/src/main/java/com/functions/ParallelFunctions.java
+++ b/samples-azure-functions/src/main/java/com/functions/ParallelFunctions.java
@@ -12,7 +12,6 @@ import com.microsoft.durabletask.azurefunctions.DurableActivityTrigger;
 import com.microsoft.durabletask.azurefunctions.DurableClientContext;
 import com.microsoft.durabletask.azurefunctions.DurableClientInput;
 import com.microsoft.durabletask.azurefunctions.DurableOrchestrationTrigger;
-import com.microsoft.durabletask.interruption.OrchestratorBlockedException;
 
 public class ParallelFunctions {
 
@@ -91,6 +90,18 @@ public class ParallelFunctions {
         return ctx.anyOf(tasks).await().await();
     }
 
+    @FunctionName("StartParallelCatchException")
+    public HttpResponseMessage startParallelCatchException(
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        DurableTaskClient client = durableContext.getClient();
+        String instanceId = client.scheduleNewOrchestrationInstance("ParallelCatchException");
+        context.getLogger().info("Created new Java orchestration with instance ID = " + instanceId);
+        return durableContext.createCheckStatusResponse(request, instanceId);
+    }
 
     @FunctionName("ParallelCatchException")
     public List<String> parallelOrchestratorSad(

--- a/samples-azure-functions/src/main/java/com/functions/ParallelFunctions.java
+++ b/samples-azure-functions/src/main/java/com/functions/ParallelFunctions.java
@@ -104,7 +104,7 @@ public class ParallelFunctions {
     }
 
     @FunctionName("ParallelCatchException")
-    public List<String> parallelOrchestratorSad(
+    public List<String> parallelCatchException(
             @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx,
             ExecutionContext context) {
         try {

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -33,7 +33,8 @@ public class EndToEndTests {
     @ValueSource(strings = {
             "StartOrchestration",
             "StartParallelOrchestration",
-            "StartParallelAnyOf"
+            "StartParallelAnyOf",
+            "ParallelCatchException"
     })
     public void generalFunctions(String functionName) throws InterruptedException {
         Set<String> continueStates = new HashSet<>();

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -34,7 +34,7 @@ public class EndToEndTests {
             "StartOrchestration",
             "StartParallelOrchestration",
             "StartParallelAnyOf",
-            "ParallelCatchException"
+            "StartParallelCatchException"
     })
     public void generalFunctions(String functionName) throws InterruptedException {
         Set<String> continueStates = new HashSet<>();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolve https://github.com/microsoft/durabletask-java/issues/169

This PR fixes the exception type for using `RetriableTask` in `allOf` method. 

Description of the issue: 

For `RetriableTask` in `allOf` method if the task failed for exception, `CompositeTaskFailedException` is not thrown out instead it's a `TaskFailedException` being thrown out. The reason is that the `CompositeTaskFailedException` that built in [exceptionPath](https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L202) haven't get chance to be obtained at [future.get()](https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L1253), [ContextImplTask.this.processNextEvent()](https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L1264C26-L1264C65) will first threw a `TaskFailedException`

For example:
```java
 @FunctionName("Parallel")
    public List<String> parallelOrchestratorSad(
            @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx,
            ExecutionContext context) {
        try {
            List<Task<String>> tasks = new ArrayList<>();
            RetryPolicy policy = new RetryPolicy(2, Duration.ofSeconds(15));
            TaskOptions options = new TaskOptions(policy);
            tasks.add(ctx.callActivity("AppendSad", "Input1", options, String.class));
            tasks.add(ctx.callActivity("AppendHappy", "Input2", options, String.class));
            return ctx.allOf(tasks).await();
        } catch (CompositeTaskFailedException e) {
            // Nothing will be caught for this type of exception. 
            for (Exception exception : e.getExceptions()) {
                if (exception instanceof TaskFailedException) {
                    TaskFailedException taskFailedException = (TaskFailedException) exception;
                    System.out.println("Task: " + taskFailedException.getTaskName() + " Failed for cause: " + taskFailedException.getErrorDetails().getErrorMessage());
                }
            }
        }
        return null;
    }
    
    @FunctionName("AppendHappy")
    public String appendHappy(
            @DurableActivityTrigger(name = "name") String name,
            final ExecutionContext context) {
        context.getLogger().info("AppendHappy: " + name);
        return name + "-test-happy";
    }
    
    @FunctionName("AppendSad")
    public String appendSad(
            @DurableActivityTrigger(name = "name") String name,
            final ExecutionContext context) {
        context.getLogger().info("Throw Test Exception: " + name);
        throw new NullPointerException("Test kaibocai exception");
    }
```

This PR ensures that any `RetriableTask` that is in `allOf` method is marked as `isInCompoundTask` so that later it uses this flag to decide whether to throw the exception or ignore it. 


### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information