### PR TITLE
Fix exception type when use RetriableTask in Fan in/out pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## placeholder
+* Fix exception type issue when using `RetriableTask` in fan in/out pattern ([#171](https://github.com/microsoft/durabletask-java/pull/171))
+
+
 ## v1.4.0
 
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## placeholder
-* Fix exception type issue when using `RetriableTask` in fan in/out pattern ([#171](https://github.com/microsoft/durabletask-java/pull/171))
+* Fix exception type issue when using `RetriableTask` in fan in/out pattern ([#174](https://github.com/microsoft/durabletask-java/pull/174))
 
 
 ## v1.4.0

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -1279,10 +1279,8 @@ final class TaskOrchestrationExecutor {
                 } catch (Exception e) {
                     // ignore
                     /**
-                     * the idea is that for any exception thrown here it should be handled
-                     * in the do-while loop, the same exception should also be obtained when calling
-                     * {code#future.get()} in the do-while loop, and it will be handled correctly
-                     * in the catch block in the do-while loop.
+                     * We ignore the exception. Any Durable Task exceptions thrown here can be obtained when calling
+                     * {code#future.get()} in the implementation of 'await'. We defer to that loop to handle the exception.
                      */
                 }
                 // Any exception happen we return true so that we will enter to the do-while block for the last time.

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -1261,7 +1261,7 @@ final class TaskOrchestrationExecutor {
                             this.handleException(e);
                         }
                     }
-                } while (ContextImplTask.this.processNextEvent());
+                } while (processNextEvent());
 
                 // There's no more history left to replay and the current task is still not completed. This is normal.
                 // The OrchestratorBlockedException exception allows us to yield the current thread back to the executor so
@@ -1269,6 +1269,22 @@ final class TaskOrchestrationExecutor {
                 // This is *not* an exception - it's a normal part of orchestrator control flow.
                 throw new OrchestratorBlockedException(
                         "The orchestrator is blocked and waiting for new inputs. This Throwable should never be caught by user code.");
+            }
+
+            private boolean processNextEvent() {
+                try {
+                    return ContextImplTask.this.processNextEvent();
+                } catch (Exception e) {
+                    // ignore
+                    /**
+                     * the idea is that for any exception thrown here it should be handled
+                     * in the do-while loop, the same exception should also be obtained when calling
+                     * {code#future.get()} in the do-while loop, and it will be handled correctly
+                     * in the catch block in the do-while loop.
+                     */
+                }
+                // Any exception happen we return true so that we will enter to the do-while block for the last time.
+                return true;
             }
 
             @Override

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -1274,6 +1274,8 @@ final class TaskOrchestrationExecutor {
             private boolean processNextEvent() {
                 try {
                     return ContextImplTask.this.processNextEvent();
+                } catch (OrchestratorBlockedException | ContinueAsNewInterruption exception) {
+                    throw exception;
                 } catch (Exception e) {
                     // ignore
                     /**

--- a/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
+++ b/samples-azure-functions/src/test/java/com/functions/EndToEndTests.java
@@ -33,7 +33,8 @@ public class EndToEndTests {
     @ValueSource(strings = {
             "StartOrchestration",
             "StartParallelOrchestration",
-            "StartParallelAnyOf"
+            "StartParallelAnyOf",
+            "StartParallelCatchException"
     })
     public void generalFunctions(String functionName) throws InterruptedException {
         Set<String> continueStates = new HashSet<>();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolve https://github.com/microsoft/durabletask-java/issues/169

This PR fixes the exception type for using `RetriableTask` in `allOf` method. 

Description of the issue: 

For `RetriableTask` in `allOf` method if the task failed for exception, `CompositeTaskFailedException` is not thrown out instead it's a `TaskFailedException` being thrown out. The reason is that the `CompositeTaskFailedException` that built in [exceptionPath](https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L202) haven't get chance to be obtained at [future.get()](https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L1253), [ContextImplTask.this.processNextEvent()](https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L1264C26-L1264C65) will first threw a `TaskFailedException`

For example:
```java
 @FunctionName("Parallel")
    public List<String> parallelOrchestratorSad(
            @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx,
            ExecutionContext context) {
        try {
            List<Task<String>> tasks = new ArrayList<>();
            RetryPolicy policy = new RetryPolicy(2, Duration.ofSeconds(15));
            TaskOptions options = new TaskOptions(policy);
            tasks.add(ctx.callActivity("AppendSad", "Input1", options, String.class));
            tasks.add(ctx.callActivity("AppendHappy", "Input2", options, String.class));
            return ctx.allOf(tasks).await();
        } catch (CompositeTaskFailedException e) {
            // Nothing will be caught for this type of exception. 
            for (Exception exception : e.getExceptions()) {
                if (exception instanceof TaskFailedException) {
                    TaskFailedException taskFailedException = (TaskFailedException) exception;
                    System.out.println("Task: " + taskFailedException.getTaskName() + " Failed for cause: " + taskFailedException.getErrorDetails().getErrorMessage());
                }
            }
        }
        return null;
    }
    
    @FunctionName("AppendHappy")
    public String appendHappy(
            @DurableActivityTrigger(name = "name") String name,
            final ExecutionContext context) {
        context.getLogger().info("AppendHappy: " + name);
        return name + "-test-happy";
    }
    
    @FunctionName("AppendSad")
    public String appendSad(
            @DurableActivityTrigger(name = "name") String name,
            final ExecutionContext context) {
        context.getLogger().info("Throw Test Exception: " + name);
        throw new NullPointerException("Test kaibocai exception");
    }
```

This PR update the `do-while` block logics so that all exception will be handle inside the block https://github.com/microsoft/durabletask-java/blob/e938278aedbfadfd8b653bae9fe7afba30d05c18/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L1264


### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information