### PR TITLE
Add deterministic GUID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## placeholder
 * Fix exception type issue when using `RetriableTask` in fan in/out pattern ([#174](https://github.com/microsoft/durabletask-java/pull/174))
+* Add implementation to generate name-based deterministic UUID ([#175](https://github.com/microsoft/durabletask-java/pull/175))
 
 
 ## v1.4.0

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Used by orchestrators to perform actions such as scheduling tasks, durable timers, waiting for external events,
@@ -299,6 +300,20 @@ public interface TaskOrchestrationContext {
      */
     default void continueAsNew(Object input){
         this.continueAsNew(input, true);
+    }
+
+    /**
+     * Create a new UUID that is safe for replay within an orchestration or operation.
+     * <p>
+     * The default implementation of this method creates a name-based UUID
+     * using the algorithm from RFC 4122 §4.3. The name input used to generate
+     * this value is a combination of the orchestration instance ID and an
+     * internally managed sequence number.
+     *</p>
+     * @return a deterministic UUID
+     */
+    default UUID newUUID() {
+        throw new RuntimeException("No implementation found.");
     }
 
     /**

--- a/client/src/main/java/com/microsoft/durabletask/util/UUIDGenerator.java
+++ b/client/src/main/java/com/microsoft/durabletask/util/UUIDGenerator.java
@@ -1,0 +1,37 @@
+package com.microsoft.durabletask.util;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+public class UUIDGenerator {
+    public static UUID generate(int version, String algorithm, UUID namespace, String name) {
+
+        MessageDigest hasher = hasher(algorithm);
+
+        if (namespace != null) {
+            ByteBuffer ns = ByteBuffer.allocate(16);
+            ns.putLong(namespace.getMostSignificantBits());
+            ns.putLong(namespace.getLeastSignificantBits());
+            hasher.update(ns.array());
+        }
+
+        hasher.update(name.getBytes(StandardCharsets.UTF_8));
+        ByteBuffer hash = ByteBuffer.wrap(hasher.digest());
+
+        final long msb = (hash.getLong() & 0xffffffffffff0fffL) | (version & 0x0f) << 12;
+        final long lsb = (hash.getLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
+
+        return new UUID(msb, lsb);
+    }
+
+    private static MessageDigest hasher(String algorithm) {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(String.format("%s not supported.", algorithm));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This is the work needed to allow orchestrations to generate random GUIDs in a deterministic way. It borrows from the similar logic in the durabletask-dotnet SDK.

Also this is request from https://github.com/dapr/java-sdk/issues/931

resolves #issue_for_this_pr

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information