### PR TITLE
Remove unused dependency - update protocVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## placeholder
+* Remove unused dependency `protobuf-java` to resolve CVEs ([#180](https://github.com/microsoft/durabletask-java/pull/180))
+
 ## v1.5.0
 * Fix exception type issue when using `RetriableTask` in fan in/out pattern ([#174](https://github.com/microsoft/durabletask-java/pull/174))
 * Add implementation to generate name-based deterministic UUID ([#176](https://github.com/microsoft/durabletask-java/pull/176))

--- a/azurefunctions/build.gradle
+++ b/azurefunctions/build.gradle
@@ -8,8 +8,6 @@ group 'com.microsoft'
 version = '1.5.0'
 archivesBaseName = 'durabletask-azure-functions'
 
-def protocVersion = '3.12.0'
-
 repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots/"
@@ -19,7 +17,6 @@ repositories {
 dependencies {
     api project(':client')
     implementation group: 'com.microsoft.azure.functions', name: 'azure-functions-java-library', version: '3.0.0'
-    implementation "com.google.protobuf:protobuf-java:${protocVersion}"
     compileOnly "com.microsoft.azure.functions:azure-functions-java-spi:1.0.0"
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -12,7 +12,7 @@ version = '1.5.0'
 archivesBaseName = 'durabletask-client'
 
 def grpcVersion = '1.59.0'
-def protocVersion = '3.12.0'
+def protocVersion = '3.25.0'
 def jacksonVersion = '2.15.3'
 // When build on local, you need to set this value to your local jdk11 directory.
 // Java11 is used to compile and run all the tests.


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/microsoft/durabletask-java/issues/179

Seems `protoc-java` is not used anywhere in `azurefunctions`. Remove it to fix the CVEs it brings to the SDK. 

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information