### PR TITLE
Fix infinite loop when use continueasnew after wait external event

### DIFF
--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -787,12 +787,17 @@ final class TaskOrchestrationExecutor {
             // We don't check the event in the pass event list to avoid duplicated events.
             Set<HistoryEvent> externalEvents = new HashSet<>(this.unprocessedEvents);
             List<HistoryEvent> newEvents = this.historyEventPlayer.getNewEvents();
+            int currentHistoryIndex = this.historyEventPlayer.getCurrentHistoryIndex();
 
-            Set<HistoryEvent> filteredEvents = newEvents.stream()
-                    .filter(e -> e.getEventTypeCase() == HistoryEvent.EventTypeCase.EVENTRAISED)
-                    .collect(Collectors.toSet());
+            // Only add events that haven't been processed to the carryOverEvents
+            // currentHistoryIndex will point to the first unprocessed event
+            for (int i = currentHistoryIndex; i < newEvents.size(); i++) {
+                HistoryEvent historyEvent = newEvents.get(i);
+                if (historyEvent.getEventTypeCase() == HistoryEvent.EventTypeCase.EVENTRAISED) {
+                    externalEvents.add(historyEvent);
+                }
+            }
 
-            externalEvents.addAll(filteredEvents);
             externalEvents.forEach(builder::addCarryoverEvents);
         }
         
@@ -946,7 +951,11 @@ final class TaskOrchestrationExecutor {
             }
 
             List<HistoryEvent> getNewEvents() {
-                return newEvents;
+                return this.newEvents;
+            }
+
+            int getCurrentHistoryIndex() {
+                return this.currentHistoryIndex;
             }
         }
 

--- a/samples-azure-functions/src/main/java/com/functions/ContinueAsNew.java
+++ b/samples-azure-functions/src/main/java/com/functions/ContinueAsNew.java
@@ -8,6 +8,7 @@ import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.Task;
 import com.microsoft.durabletask.TaskOrchestrationContext;
 import com.microsoft.durabletask.azurefunctions.DurableClientContext;
 import com.microsoft.durabletask.azurefunctions.DurableClientInput;
@@ -36,5 +37,30 @@ public class ContinueAsNew {
         System.out.println("Processing stuff...");
         ctx.createTimer(Duration.ofSeconds(2)).await();
         ctx.continueAsNew(null);
+    }
+
+    @FunctionName("ContinueAsNewExternalEvent")
+    public HttpResponseMessage continueAsNewExternalEvent(
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        DurableTaskClient client = durableContext.getClient();
+        String instanceId = client.scheduleNewOrchestrationInstance("EternalEvent");
+        context.getLogger().info("Created new Java orchestration with instance ID = " + instanceId);
+        return durableContext.createCheckStatusResponse(request, instanceId);
+    }
+
+    @FunctionName("EternalEvent")
+    public void eternalEvent(@DurableOrchestrationTrigger(name = "runtimeState") TaskOrchestrationContext ctx)
+    {
+        System.out.println("Waiting external event...");
+        Task<Void> event = ctx.waitForExternalEvent("event");
+        Task<Void> timer = ctx.createTimer(Duration.ofSeconds(10));
+        Task<?> result = ctx.anyOf(event, timer).await();
+        if (result == event) {
+            ctx.continueAsNew(null);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/microsoft/durabletask-java/issues/182

This PR fix a bug with the `carrayOverEvents` of `continueAsNew` API. The old implementation loops through the whole `newEvents` list to add `EVENTRAISED` to `carrayOverEvents`, which is not correct. With this fix, it only loops through events that haven't been processed in the `newEvents` list. 

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes are added to the `CHANGELOG.md`
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information