### PR TITLE
Support orchestration id reuse policy

### DIFF
--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -4,6 +4,7 @@ package com.microsoft.durabletask;
 
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import com.microsoft.durabletask.client.InstanceIdReuseAction;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.*;
 import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc;
 import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc.*;
@@ -86,6 +87,17 @@ final class DurableTaskGrpcClient extends DurableTaskClient {
 
         CreateInstanceRequest.Builder builder = CreateInstanceRequest.newBuilder();
         builder.setName(orchestratorName);
+
+        // build orchestration ID reuse policy
+        OrchestrationIdReusePolicy.Builder reuseIdPolicyBuilder = OrchestrationIdReusePolicy.newBuilder();
+        // if options.getInstanceIdReuseAction() is null, default value will be ERROR
+        if (options.getInstanceIdReuseAction() != null) {
+            reuseIdPolicyBuilder.setAction(InstanceIdReuseAction.toProtobuf(options.getInstanceIdReuseAction()));
+        }
+        for (OrchestrationRuntimeStatus targetStatus : options.getTargetStatuses()) {
+            reuseIdPolicyBuilder.addOperationStatus(OrchestrationRuntimeStatus.toProtobuf(targetStatus));
+        }
+        builder.setOrchestrationIdReusePolicy(reuseIdPolicyBuilder);
 
         String instanceId = options.getInstanceId();
         if (instanceId == null) {

--- a/client/src/main/java/com/microsoft/durabletask/NewOrchestrationInstanceOptions.java
+++ b/client/src/main/java/com/microsoft/durabletask/NewOrchestrationInstanceOptions.java
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 package com.microsoft.durabletask;
 
+import com.microsoft.durabletask.client.InstanceIdReuseAction;
+
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Options for starting a new instance of an orchestration.
@@ -12,6 +17,8 @@ public final class NewOrchestrationInstanceOptions {
     private String instanceId;
     private Object input;
     private Instant startTime;
+    private final Set<OrchestrationRuntimeStatus> targetStatuses = new HashSet<>();
+    private InstanceIdReuseAction instanceIdReuseAction;
 
     /**
      * Default constructor for the {@link NewOrchestrationInstanceOptions} class.
@@ -72,6 +79,104 @@ public final class NewOrchestrationInstanceOptions {
     }
 
     /**
+     * Sets the target statuses for the reuse orchestration ID policy of the new orchestration instance.
+     * This method allows specifying the desired statuses for orchestrations with the same ID
+     * when configuring the orchestration ID reuse policy.
+     *
+     * <p>
+     * By default, the {@code targetStatuses} is empty. If an orchestration with the same instance ID
+     * already exists, an error will be thrown, indicating a duplicate orchestration instance.
+     * You can customize the orchestration ID reuse policy by setting the {@code targetStatuses}
+     * and {@code instanceIdReuseAction}.
+     *
+     * <p>
+     * For example, the following options will terminate an existing orchestration instance with the same instance ID
+     * if it's in RUNNING, FAILED, or COMPLETED runtime status:
+     * <pre>{@code
+     * NewOrchestrationInstanceOptions options = new NewOrchestrationInstanceOptions();
+     * options.addTargetStatus(OrchestrationRuntimeStatus.RUNNING, OrchestrationRuntimeStatus.FAILED,
+     *                         OrchestrationRuntimeStatus.COMPLETED);
+     * options.setInstanceIdReuseAction(InstanceIdReuseAction.TERMINATE);
+     * }</pre>
+     *
+     * @param statuses The target statuses for the reuse orchestration ID policy when creating the new orchestration instance.
+     * @return This {@link NewOrchestrationInstanceOptions} object.
+     */
+    public NewOrchestrationInstanceOptions addTargetStatus(OrchestrationRuntimeStatus... statuses) {
+        for (OrchestrationRuntimeStatus status : statuses) {
+            this.addTargetStatus(status);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the target statuses for the reuse orchestration ID policy of the new orchestration instance.
+     * This method allows specifying the desired statuses for orchestrations with the same ID
+     * when configuring the orchestration ID reuse policy.
+     *
+     * <p>
+     * By default, the {@code targetStatuses} is empty. If an orchestration with the same instance ID
+     * already exists, an error will be thrown, indicating a duplicate orchestration instance.
+     * You can customize the orchestration ID reuse policy by setting the {@code targetStatuses}
+     * and {@code instanceIdReuseAction}.
+     *
+     * <p>
+     * For example, the following options will terminate an existing orchestration instance with the same instance ID
+     * if it's in RUNNING, FAILED, or COMPLETED runtime status:
+     *<pre>{@code
+     * NewOrchestrationInstanceOptions option = new NewOrchestrationInstanceOptions();
+     * List<OrchestrationRuntimeStatus> statuses = new ArrayList<>();
+     * statuses.add(RUNNING);
+     * statuses.add(FAILED);
+     * statuses.add(COMPLETED);
+     * option.setTargetStatus(statuses);
+     * option.setInstanceIdReuseAction(TERMINATE);
+     * }
+     *</pre>
+     * @param statuses A list of target statuses for the reuse orchestration ID policy of creating the new orchestration instance.
+     * @return this {@link NewOrchestrationInstanceOptions} object
+     */
+    public NewOrchestrationInstanceOptions setTargetStatus(List<OrchestrationRuntimeStatus> statuses) {
+        for (OrchestrationRuntimeStatus status : statuses) {
+            this.addTargetStatus(status);
+        }
+        return this;
+    }
+
+    private void addTargetStatus(OrchestrationRuntimeStatus status) {
+        this.targetStatuses.add(status);
+    }
+
+    /**
+     * Sets the target action for the reuse orchestration ID policy of the new orchestration instance.
+     * This method allows specifying the desired action for orchestrations with the same ID
+     * when configuring the orchestration ID reuse policy.
+     *
+     * <p>
+     * By default, the {@code instanceIdReuseAction} is {@code InstanceIdReuseAction.ERROR}. If an orchestration with the same instance ID
+     * already exists, an error will be thrown, indicating a duplicate orchestration instance.
+     * You can customize the orchestration ID reuse policy by setting the {@code targetStatuses}
+     * and {@code instanceIdReuseAction}.
+     *
+     * <p>
+     * For example, the following options will terminate an existing orchestration instance with the same instance ID
+     * if it's in RUNNING, FAILED, or COMPLETED runtime status:
+     * <pre>{@code
+     * NewOrchestrationInstanceOptions options = new NewOrchestrationInstanceOptions();
+     * options.addTargetStatus(OrchestrationRuntimeStatus.RUNNING, OrchestrationRuntimeStatus.FAILED,
+     *                         OrchestrationRuntimeStatus.COMPLETED);
+     * options.setInstanceIdReuseAction(InstanceIdReuseAction.TERMINATE);
+     * }</pre>
+     *
+     * @param instanceIdReuseAction The target action for the reuse orchestration ID policy when creating the new orchestration instance.
+     * @return This {@link NewOrchestrationInstanceOptions} object.
+     */
+    public NewOrchestrationInstanceOptions setInstanceIdReuseAction(InstanceIdReuseAction instanceIdReuseAction) {
+        this.instanceIdReuseAction = instanceIdReuseAction;
+        return this;
+    }
+
+    /**
      * Gets the user-specified version of the new orchestration.
      *
      * @return the user-specified version of the new orchestration.
@@ -105,5 +210,23 @@ public final class NewOrchestrationInstanceOptions {
      */
     public Instant getStartTime() {
         return this.startTime;
+    }
+
+    /**
+     * Gets the target statuses for the reuse orchestration ID policy of the new orchestration instance.
+     *
+     * @return The target statuses for the reuse orchestration ID policy when creating the new orchestration instance.
+     */
+    public Set<OrchestrationRuntimeStatus> getTargetStatuses() {
+        return this.targetStatuses;
+    }
+
+    /**
+     * Gets the target action for the reuse orchestration ID policy of the new orchestration instance.
+     *
+     * @return The target action for the reuse orchestration ID policy when creating the new orchestration instance.
+     */
+    public InstanceIdReuseAction getInstanceIdReuseAction() {
+        return this.instanceIdReuseAction;
     }
 }

--- a/client/src/main/java/com/microsoft/durabletask/client/InstanceIdReuseAction.java
+++ b/client/src/main/java/com/microsoft/durabletask/client/InstanceIdReuseAction.java
@@ -1,0 +1,23 @@
+package com.microsoft.durabletask.client;
+
+import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
+
+public enum InstanceIdReuseAction {
+  ERROR,
+  IGNORE,
+  TERMINATE;
+
+  public static OrchestratorService.CreateOrchestrationAction toProtobuf(
+      InstanceIdReuseAction action) {
+    switch (action) {
+      case ERROR:
+        return OrchestratorService.CreateOrchestrationAction.ERROR;
+      case IGNORE:
+        return OrchestratorService.CreateOrchestrationAction.IGNORE;
+      case TERMINATE:
+        return OrchestratorService.CreateOrchestrationAction.TERMINATE;
+      default:
+        throw new IllegalArgumentException(String.format("Unknown action value: %s", action));
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR adds support for the orchestration id reuse policy. It asking for corresponding server updates at https://github.com/microsoft/durabletask-go/pull/46

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information