### PR TITLE
Add initial 1ES migration

### DIFF
--- a/azurefunctions/build.gradle
+++ b/azurefunctions/build.gradle
@@ -76,9 +76,10 @@ publishing {
     }
 }
 
-signing {
-    sign publishing.publications.mavenJava
-}
+// TODO: manual signing temporarily disabled, in favor of 1ES signing utils
+//signing {
+//    sign publishing.publications.mavenJava
+//}
 
 java {
     withSourcesJar()

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -146,9 +146,10 @@ publishing {
     }
 }
 
-signing {
-    sign publishing.publications.mavenJava
-}
+// TODO: manual signing temporarily disabled, in favor of 1ES signing
+//signing {
+//    sign publishing.publications.mavenJava
+//}
 
 java {
     withSourcesJar()

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,0 +1,36 @@
+variables:
+  - template: ci/variables/cfs.yml@eng
+
+trigger:
+    batch: true
+    branches:
+        include:
+            - main
+
+# CI only, does not trigger on PRs.
+pr: none
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        pool:
+            name: 1es-pool-azfunc
+            image: 1es-windows-2022
+            os: windows
+
+        stages:
+            - stage: BuildAndSign
+              dependsOn: []
+              jobs:
+                  - template: /eng/templates/build.yml@self

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -1,0 +1,48 @@
+jobs:
+    - job: Build
+
+      templateContext:
+          outputs:
+              - output: pipelineArtifact
+                path: $(build.artifactStagingDirectory)
+                artifact: drop
+                sbomBuildDropPath: $(System.DefaultWorkingDirectory)
+                sbomPackageName: 'Durable Task / Durable Functions Java SBOM'
+
+      steps:
+        - checkout: self
+          submodules: true
+
+        - task: Gradle@3
+          inputs:
+            # Specifies the working directory to run the Gradle build. The task uses the repository root directory if the working directory is not specified.
+            workingDirectory: ''
+            # Specifies the gradlew wrapper's location within the repository that will be used for the build.
+            gradleWrapperFile: 'gradlew'
+            # Sets the GRADLE_OPTS environment variable, which is used to send command-line arguments to start the JVM. The xmx flag specifies the maximum memory available to the JVM.
+            gradleOptions: '-Xmx3072m'
+            javaHomeOption: 'JDKVersion'
+            jdkVersionOption: 1.11
+            jdkArchitectureOption: 'x64'
+            publishJUnitResults: false
+            tasks: clean assemble
+          displayName: Assemble durabletask-client and durabletask-azure-functions
+
+        # TODO: add 1ES-level signing
+        - task: Gradle@3
+          inputs:
+            workingDirectory: ''
+            gradleWrapperFile: 'gradlew'
+            gradleOptions: '-Xmx3072m'
+            javaHomeOption: 'JDKVersion'
+            jdkVersionOption: 1.11
+            jdkArchitectureOption: 'x64'
+            tasks: publish
+          displayName: Publish durabletask-client and durabletask-azure-functions
+
+        - task: CopyFiles@2
+          displayName: 'Copy publish file to Artifact Staging Directory'
+          inputs:
+            SourceFolder: $(System.DefaultWorkingDirectory)/repo/com/microsoft
+            Contents: '**/*.*'
+            TargetFolder: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
This PR adds an initial 1ES official pipeline. In order to do this, it removes the previous "manual" signing step in favor of the 1ES signing utils (which are yet to be added). Therefore, packages produced by this pipeline should not be released _yet_, at least not until we figure out how to incorporate the 1ES signing tool for Java.