### PR TITLE
Update DurableTaskJava release pipeline configuration to use 'main' b…

### DIFF
--- a/eng/ci/release.yml
+++ b/eng/ci/release.yml
@@ -10,6 +10,7 @@ resources:
   pipelines:
   - pipeline: DurableTaskJavaBuildPipeline
     source: durabletask-java.official
+    branch: main
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -31,6 +32,7 @@ extends:
           - input: pipelineArtifact
             pipeline: DurableTaskJavaBuildPipeline
             artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
 
         steps:
         - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
@@ -41,7 +43,7 @@ extends:
             keyvaultname: 'durable-esrp-akv'
             signcertname: 'dts-esrp-cert'
             clientid: '0b3ed1a4-0727-4a50-b82a-02c2bd9dec89'
-            folderlocation: '$(System.DefaultWorkingDirectory)/_durabletask-java.official/drop/durabletask-azuremanaged'
+            folderlocation: '$(System.DefaultWorkingDirectory)/drop/durabletask-azuremanaged'
             owners: 'wangbill@microsoft.com'
             approvers: 'kaibocai@microsoft.com'
             mainpublisher: 'durabletask-java'
@@ -55,6 +57,7 @@ extends:
           - input: pipelineArtifact
             pipeline: DurableTaskJavaBuildPipeline
             artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
 
         steps:
         - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
@@ -65,7 +68,7 @@ extends:
             keyvaultname: 'durable-esrp-akv'
             signcertname: 'dts-esrp-cert'
             clientid: '0b3ed1a4-0727-4a50-b82a-02c2bd9dec89'
-            folderlocation: '$(System.DefaultWorkingDirectory)/_durabletask-java.official/drop/durabletask-client'
+            folderlocation: '$(System.DefaultWorkingDirectory)/drop/durabletask-client'
             owners: 'wangbill@microsoft.com'
             approvers: 'kaibocai@microsoft.com'
             mainpublisher: 'durabletask-java'
@@ -79,6 +82,7 @@ extends:
           - input: pipelineArtifact
             pipeline: DurableTaskJavaBuildPipeline
             artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
 
         steps:
         - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
@@ -89,7 +93,7 @@ extends:
             keyvaultname: 'durable-esrp-akv'
             signcertname: 'dts-esrp-cert'
             clientid: '0b3ed1a4-0727-4a50-b82a-02c2bd9dec89'
-            folderlocation: '$(System.DefaultWorkingDirectory)/_durabletask-java.official/drop/durabletask-azure-functions'
+            folderlocation: '$(System.DefaultWorkingDirectory)/drop/durabletask-azure-functions'
             owners: 'wangbill@microsoft.com'
             approvers: 'kaibocai@microsoft.com'
             mainpublisher: 'durabletask-java'


### PR DESCRIPTION
This pull request updates the `eng/ci/release.yml` file to streamline artifact handling and simplify folder paths in the release pipeline configuration. The changes primarily focus on standardizing the artifact paths and ensuring consistency across multiple pipeline steps.

### Artifact Path Updates:
* Updated the `folderlocation` paths to remove the `_durabletask-java.official` prefix, simplifying the directory structure for artifacts like `durabletask-azuremanaged`, `durabletask-client`, and `durabletask-azure-functions`. (`[[1]](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3L44-R46)`, `[[2]](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3L68-R71)`, `[[3]](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3L92-R96)`)

### Pipeline Configuration Enhancements:
* Added `targetPath` to specify the target directory for pipeline artifacts as `$(System.DefaultWorkingDirectory)/drop` for multiple steps. (`[[1]](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3R35)`, `[[2]](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3R60)`, `[[3]](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3R85)`)
* Explicitly set the branch to `main` for the `DurableTaskJavaBuildPipeline` source, ensuring the pipeline operates on the correct branch. (`[eng/ci/release.ymlR13](diffhunk://#diff-0b4964880447dddb515c7c134cb70a41bcf08f9fbea7b9bf1453a121e49ffda3R13)`)…ranch and adjust folder locations for artifacts

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information