### PR TITLE
Introduce versioning into the Java SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Unreleased
 * Add support for tags when creating new orchestrations ([#231](https://github.com/microsoft/durabletask-java/pull/230))
+* Add versioning support for client and worker ([#224](https://github.com/microsoft/durabletask-java/pull/224))
 
 ## v1.5.2
 * Add distributed tracing support for Azure Functions client scenarios ([#211](https://github.com/microsoft/durabletask-java/pull/211))
-
 
 ## v1.5.1
 * Improve logging for unexpected connection failures in DurableTaskGrpcWorker ([#216](https://github.com/microsoft/durabletask-java/pull/216/files))

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -32,9 +32,11 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     private final DataConverter dataConverter;
     private final ManagedChannel managedSidecarChannel;
     private final TaskHubSidecarServiceBlockingStub sidecarClient;
+    private final String defaultVersion;
 
     DurableTaskGrpcClient(DurableTaskGrpcClientBuilder builder) {
         this.dataConverter = builder.dataConverter != null ? builder.dataConverter : new JacksonDataConverter();
+        this.defaultVersion = builder.defaultVersion;
 
         Channel sidecarGrpcChannel;
         if (builder.channel != null) {
@@ -100,6 +102,8 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
         String version = options.getVersion();
         if (version != null) {
             builder.setVersion(StringValue.of(version));
+        } else if (this.defaultVersion != null) {
+            builder.setVersion(StringValue.of(this.defaultVersion));
         }
 
         Object input = options.getInput();

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClientBuilder.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClientBuilder.java
@@ -12,6 +12,7 @@ public final class DurableTaskGrpcClientBuilder {
     DataConverter dataConverter;
     int port;
     Channel channel;
+    String defaultVersion;
 
     /**
      * Sets the {@link DataConverter} to use for converting serializable data payloads.
@@ -50,6 +51,17 @@ public final class DurableTaskGrpcClientBuilder {
      */
     public DurableTaskGrpcClientBuilder port(int port) {
         this.port = port;
+        return this;
+    }
+
+    /**
+     * Sets the default version that orchestrations will be created with.
+     * 
+     * @param defaultVersion the default version to create orchestrations with
+     * @return this builder object
+     */
+    public DurableTaskGrpcClientBuilder defaultVersion(String defaultVersion) {
+        this.defaultVersion = defaultVersion;
         return this;
     }
 

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
@@ -8,6 +8,7 @@ import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGr
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.*;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.WorkItem.RequestCase;
 import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc.*;
+import com.microsoft.durabletask.util.VersionUtils;
 
 import io.grpc.*;
 
@@ -16,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
  * Task hub worker that connects to a sidecar process over gRPC to execute orchestrator and activity events.
@@ -31,6 +33,7 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
     private final ManagedChannel managedSidecarChannel;
     private final DataConverter dataConverter;
     private final Duration maximumTimerInterval;
+    private final DurableTaskGrpcWorkerVersioningOptions versioningOptions;
 
     private final TaskHubSidecarServiceBlockingStub sidecarClient;
 
@@ -61,6 +64,7 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
         this.sidecarClient = TaskHubSidecarServiceGrpc.newBlockingStub(sidecarGrpcChannel);
         this.dataConverter = builder.dataConverter != null ? builder.dataConverter : new JacksonDataConverter();
         this.maximumTimerInterval = builder.maximumTimerInterval != null ? builder.maximumTimerInterval : DEFAULT_MAXIMUM_TIMER_INTERVAL;
+        this.versioningOptions = builder.versioningOptions;
     }
 
     /**
@@ -130,20 +134,87 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
                     if (requestType == RequestCase.ORCHESTRATORREQUEST) {
                         OrchestratorRequest orchestratorRequest = workItem.getOrchestratorRequest();
 
+                        // If versioning is set, process it first to see if the orchestration should be executed.
+                        boolean versioningFailed = false;
+                        if (versioningOptions != null && versioningOptions.getVersion() != null) {
+                            String version = Stream.concat(orchestratorRequest.getPastEventsList().stream(), orchestratorRequest.getNewEventsList().stream())
+                                .filter(event -> event.getEventTypeCase() == HistoryEvent.EventTypeCase.EXECUTIONSTARTED)
+                                .map(event -> event.getExecutionStarted().getVersion().getValue())
+                                .findFirst()
+                                .orElse(null);
+
+                            if (version != null) {
+                                int comparison = VersionUtils.compareVersions(version, versioningOptions.getVersion());
+
+                                switch (versioningOptions.getMatchStrategy()) {
+                                    case NONE:
+                                        break;
+                                    case STRICT:
+                                        if (comparison != 0) {
+                                            logger.log(Level.WARNING, String.format("The orchestration version '%s' does not match the worker version '%s'.", version, versioningOptions.getVersion()));
+                                            versioningFailed = true;
+                                        }
+                                        break;
+                                    case CURRENTOROLDER:
+                                        if (comparison > 0) {
+                                            logger.log(Level.WARNING, String.format("The orchestration version '%s' is greater than the worker version '%s'.", version, versioningOptions.getVersion()));
+                                            versioningFailed = true;
+                                        }
+                                        break;
+                                    default:
+                                        logger.log(Level.SEVERE, String.format("Unknown version match strategy '%s'.", versioningOptions.getMatchStrategy()));
+                                        versioningFailed = true;
+                                        break;
+                                }
+                            }
+                        }
+
                         // TODO: Run this on a worker pool thread: https://www.baeldung.com/thread-pool-java-and-guava
                         // TODO: Error handling
-                        TaskOrchestratorResult taskOrchestratorResult = taskOrchestrationExecutor.execute(
+                        if (!versioningFailed) {
+                            TaskOrchestratorResult taskOrchestratorResult = taskOrchestrationExecutor.execute(
                                 orchestratorRequest.getPastEventsList(),
                                 orchestratorRequest.getNewEventsList());
 
-                        OrchestratorResponse response = OrchestratorResponse.newBuilder()
-                                .setInstanceId(orchestratorRequest.getInstanceId())
-                                .addAllActions(taskOrchestratorResult.getActions())
-                                .setCustomStatus(StringValue.of(taskOrchestratorResult.getCustomStatus()))
-                                .setCompletionToken(workItem.getCompletionToken())
-                                .build();
+                            OrchestratorResponse response = OrchestratorResponse.newBuilder()
+                                    .setInstanceId(orchestratorRequest.getInstanceId())
+                                    .addAllActions(taskOrchestratorResult.getActions())
+                                    .setCustomStatus(StringValue.of(taskOrchestratorResult.getCustomStatus()))
+                                    .setCompletionToken(workItem.getCompletionToken())
+                                    .build();
 
-                        this.sidecarClient.completeOrchestratorTask(response);
+                            this.sidecarClient.completeOrchestratorTask(response);
+                        } else {
+                            switch(versioningOptions.getFailureStrategy()) {
+                                case FAIL:
+                                    CompleteOrchestrationAction completeAction = CompleteOrchestrationAction.newBuilder()
+                                        .setOrchestrationStatus(OrchestrationStatus.ORCHESTRATION_STATUS_FAILED)
+                                        .setFailureDetails(TaskFailureDetails.newBuilder()
+                                            .setErrorType("VersionMismatch")
+                                            .setErrorMessage("The orchestration version does not match the worker version.")
+                                            .build())
+                                        .build();
+
+                                    OrchestratorAction action = OrchestratorAction.newBuilder()
+                                        .setCompleteOrchestration(completeAction)
+                                        .build();
+
+                                    OrchestratorResponse response = OrchestratorResponse.newBuilder()
+                                        .setInstanceId(orchestratorRequest.getInstanceId())
+                                        .setCompletionToken(workItem.getCompletionToken())
+                                        .addActions(action)
+                                        .build();
+
+                                    this.sidecarClient.completeOrchestratorTask(response);
+                                    break;
+                                // Reject and default share the same behavior as it does not change the orchestration to a terminal state.
+                                case REJECT:
+                                default:
+                                    this.sidecarClient.abandonTaskOrchestratorWorkItem(AbandonOrchestrationTaskRequest.newBuilder()
+                                        .setCompletionToken(workItem.getCompletionToken())
+                                        .build());
+                            }
+                        }                        
                     } else if (requestType == RequestCase.ACTIVITYREQUEST) {
                         ActivityRequest activityRequest = workItem.getActivityRequest();
 

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorker.java
@@ -117,7 +117,8 @@ public final class DurableTaskGrpcWorker implements AutoCloseable {
                 this.orchestrationFactories,
                 this.dataConverter,
                 this.maximumTimerInterval,
-                logger);
+                logger,
+                this.versioningOptions);
         TaskActivityExecutor taskActivityExecutor = new TaskActivityExecutor(
                 this.activityFactories,
                 this.dataConverter,

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerBuilder.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerBuilder.java
@@ -17,6 +17,7 @@ public final class DurableTaskGrpcWorkerBuilder {
     Channel channel;
     DataConverter dataConverter;
     Duration maximumTimerInterval;
+    DurableTaskGrpcWorkerVersioningOptions versioningOptions;
 
     /**
      * Adds an orchestration factory to be used by the constructed {@link DurableTaskGrpcWorker}.
@@ -110,6 +111,17 @@ public final class DurableTaskGrpcWorkerBuilder {
      */
     public DurableTaskGrpcWorkerBuilder maximumTimerInterval(Duration maximumTimerInterval) {
         this.maximumTimerInterval = maximumTimerInterval;
+        return this;
+    }
+
+    /**
+     * Sets the versioning options for this worker.
+     * 
+     * @param options the versioning options to use
+     * @return this builder object
+     */
+    public DurableTaskGrpcWorkerBuilder useVersioning(DurableTaskGrpcWorkerVersioningOptions options) {
+        this.versioningOptions = options;
         return this;
     }
 

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerVersioningOptions.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcWorkerVersioningOptions.java
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+/**
+ * Options for configuring versioning behavior in the DurableTaskGrpcWorker.
+ */
+public final class DurableTaskGrpcWorkerVersioningOptions {
+
+    /**
+     * Strategy for matching versions.
+     * NONE: No version matching is performed.
+     * STRICT: The version must match exactly.
+     * CURRENTOROLDER: The version must be the current version or older.
+     */
+    public enum VersionMatchStrategy {
+        NONE,
+        STRICT,
+        CURRENTOROLDER;
+    }
+
+    /**
+     * Strategy for handling version mismatches.
+     * REJECT: Reject the orchestration if the version does not match. The orchestration will be retried later.
+     * FAIL: Fail the orchestration if the version does not match.
+     */
+    public enum VersionFailureStrategy {
+        REJECT,
+        FAIL;
+    }
+
+    private final String version;
+    private final String defaultVersion;
+    private final VersionMatchStrategy matchStrategy;
+    private final VersionFailureStrategy failureStrategy;
+
+    /**
+     * Constructor for DurableTaskGrpcWorkerVersioningOptions.
+     * @param version the version that is matched against orchestrations
+     * @param defaultVersion the default version used when starting sub orchestrations from this worker
+     * @param matchStrategy the strategy for matching versions
+     * @param failureStrategy the strategy for handling version mismatches
+     */
+    public DurableTaskGrpcWorkerVersioningOptions(String version, String defaultVersion, VersionMatchStrategy matchStrategy, VersionFailureStrategy failureStrategy) {
+        this.version = version;
+        this.defaultVersion = defaultVersion;
+        this.matchStrategy = matchStrategy;
+        this.failureStrategy = failureStrategy;
+    }
+
+    /**
+     * Gets the version that is matched against orchestrations.
+     * @return the version that is matched against orchestrations
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Gets the default version used when starting sub orchestrations from this worker.
+     * @return the default version used when starting sub orchestrations from this worker
+     */
+    public String getDefaultVersion() {
+        return defaultVersion;
+    }
+
+    /**
+     * Gets the strategy for matching versions.
+     * @return the strategy for matching versions
+     */
+    public VersionMatchStrategy getMatchStrategy() {
+        return matchStrategy;
+    }
+
+    /**
+     * Gets the strategy for handling version mismatches.
+     * @return the strategy for handling version mismatches
+     */
+    public VersionFailureStrategy getFailureStrategy() {
+        return failureStrategy;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/NewSubOrchestrationInstanceOptions.java
+++ b/client/src/main/java/com/microsoft/durabletask/NewSubOrchestrationInstanceOptions.java
@@ -1,0 +1,62 @@
+package com.microsoft.durabletask;
+
+/**
+ * Options for starting a new sub-orchestration instance.
+ */
+public class NewSubOrchestrationInstanceOptions extends TaskOptions {
+
+    private String instanceId;
+    private String version;
+
+    /**
+     * Creates options with a retry policy for the sub-orchestration.
+     * @param retryPolicy The retry policy to use for the sub-orchestration.
+     */
+    public NewSubOrchestrationInstanceOptions(RetryPolicy retryPolicy) {
+        super(retryPolicy);
+    }
+
+    /**
+     * Creates options with a retry handler for the sub-orchestration.
+     * @param retryHandler The retry handler to use for the sub-orchestration.
+     */
+    public NewSubOrchestrationInstanceOptions(RetryHandler retryHandler) {
+        super(retryHandler);
+    }
+
+    /**
+     * Sets the version for the sub-orchestration instance.
+     * @param version The version string to use.
+     * @return This options object for chaining.
+     */
+    public NewSubOrchestrationInstanceOptions setVersion(String version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Gets the version for the sub-orchestration instance.
+     * @return The version string, or null if not set.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Sets a custom instance ID for the sub-orchestration.
+     * @param instanceId The custom instance ID to use.
+     * @return This options object for chaining.
+     */
+    public NewSubOrchestrationInstanceOptions setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+        return this;
+    }
+
+    /**
+     * Gets the custom instance ID for the sub-orchestration.
+     * @return The instance ID, or null if not set.
+     */
+    public String getInstanceId() {
+        return instanceId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
+++ b/client/src/main/java/com/microsoft/durabletask/OrchestrationRunner.java
@@ -129,7 +129,8 @@ public final class OrchestrationRunner {
                 orchestrationFactories,
                 new JacksonDataConverter(),
                 DEFAULT_MAXIMUM_TIMER_INTERVAL,
-                logger);
+                logger,
+                null);
 
         // TODO: Error handling
         TaskOrchestratorResult taskOrchestratorResult = taskOrchestrationExecutor.execute(

--- a/client/src/main/java/com/microsoft/durabletask/TaskOptions.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOptions.java
@@ -5,7 +5,7 @@ package com.microsoft.durabletask;
 /**
  * Options that can be used to control the behavior of orchestrator and activity task execution.
  */
-public final class TaskOptions {
+public class TaskOptions {
     private final RetryPolicy retryPolicy;
     private final RetryHandler retryHandler;
 

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationContext.java
@@ -60,6 +60,13 @@ public interface TaskOrchestrationContext {
     boolean getIsReplaying();
 
     /**
+     * Gets the version of the orchestration that this context represents.
+     * 
+     * @return the version of the orchestration
+     */
+    String getVersion();
+
+    /**
      * Returns a new {@code Task} that is completed when all tasks in {@code tasks} completes.
      * See {@link #allOf(Task[])} for more detailed information.
      *

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -409,9 +409,7 @@ final class TaskOrchestrationExecutor {
 
             if (options instanceof NewSubOrchestrationInstanceOptions && ((NewSubOrchestrationInstanceOptions)options).getVersion() != null) {
                 NewSubOrchestrationInstanceOptions subOrchestrationOptions = (NewSubOrchestrationInstanceOptions) options;
-                if (subOrchestrationOptions.getVersion() != null) {
-                    createSubOrchestrationActionBuilder.setVersion(StringValue.of(subOrchestrationOptions.getVersion()));
-                }
+                createSubOrchestrationActionBuilder.setVersion(StringValue.of(subOrchestrationOptions.getVersion()));
             } else if (this.getDefaultVersion() != null) {
                 // If the options are not of the correct type, we still allow the version to be set
                 createSubOrchestrationActionBuilder.setVersion(StringValue.of(this.getDefaultVersion()));

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -81,6 +81,7 @@ final class TaskOrchestrationExecutor {
         private boolean isSuspended;
         private boolean isReplaying = true;
         private int newUUIDCounter;
+        private String version;
 
         // LinkedHashMap to maintain insertion order when returning the list of pending actions
         private final LinkedHashMap<Integer, OrchestratorAction> pendingActions = new LinkedHashMap<>();
@@ -170,6 +171,15 @@ final class TaskOrchestrationExecutor {
 
         private void setDoneReplaying() {
             this.isReplaying = false;
+        }
+
+        @Override
+        public String getVersion() {
+            return this.version;
+        }
+
+        private void setVersion(String version) {
+            this.version = version;
         }
 
         public <V> Task<V> completedTask(V value) {
@@ -839,6 +849,8 @@ final class TaskOrchestrationExecutor {
                         this.setInstanceId(instanceId);
                         String input = startedEvent.getInput().getValue();
                         this.setInput(input);
+                        String version = startedEvent.getVersion().getValue();
+                        this.setVersion(version);
                         TaskOrchestrationFactory factory = TaskOrchestrationExecutor.this.orchestrationFactories.get(name);
                         if (factory == null) {
                             // Try getting the default orchestrator

--- a/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
+++ b/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java
@@ -30,20 +30,28 @@ final class TaskOrchestrationExecutor {
     private final DataConverter dataConverter;
     private final Logger logger;
     private final Duration maximumTimerInterval;
+    private final DurableTaskGrpcWorkerVersioningOptions versioningOptions;
 
     public TaskOrchestrationExecutor(
             HashMap<String, TaskOrchestrationFactory> orchestrationFactories,
             DataConverter dataConverter,
             Duration maximumTimerInterval,
-            Logger logger) {
+            Logger logger,
+            DurableTaskGrpcWorkerVersioningOptions versioningOptions) {
         this.orchestrationFactories = orchestrationFactories;
         this.dataConverter = dataConverter;
         this.maximumTimerInterval = maximumTimerInterval;
         this.logger = logger;
+        this.versioningOptions = versioningOptions;
     }
 
     public TaskOrchestratorResult execute(List<HistoryEvent> pastEvents, List<HistoryEvent> newEvents) {
         ContextImplTask context = new ContextImplTask(pastEvents, newEvents);
+
+        if (this.versioningOptions != null && this.versioningOptions.getDefaultVersion() != null) {
+            // Set the default version for the orchestrator
+            context.setDefaultVersion(this.versioningOptions.getDefaultVersion());
+        }
 
         boolean completed = false;
         try {
@@ -82,6 +90,7 @@ final class TaskOrchestrationExecutor {
         private boolean isReplaying = true;
         private int newUUIDCounter;
         private String version;
+        private String defaultVersion;
 
         // LinkedHashMap to maintain insertion order when returning the list of pending actions
         private final LinkedHashMap<Integer, OrchestratorAction> pendingActions = new LinkedHashMap<>();
@@ -180,6 +189,15 @@ final class TaskOrchestrationExecutor {
 
         private void setVersion(String version) {
             this.version = version;
+        }
+
+        private String getDefaultVersion() {
+            return this.defaultVersion;
+        }
+
+        private void setDefaultVersion(String defaultVersion) {
+            // This is used when starting sub-orchestrations
+            this.defaultVersion = defaultVersion;
         }
 
         public <V> Task<V> completedTask(V value) {
@@ -388,6 +406,16 @@ final class TaskOrchestrationExecutor {
                 instanceId = this.newUUID().toString();
             }
             createSubOrchestrationActionBuilder.setInstanceId(instanceId);
+
+            if (options instanceof NewSubOrchestrationInstanceOptions && ((NewSubOrchestrationInstanceOptions)options).getVersion() != null) {
+                NewSubOrchestrationInstanceOptions subOrchestrationOptions = (NewSubOrchestrationInstanceOptions) options;
+                if (subOrchestrationOptions.getVersion() != null) {
+                    createSubOrchestrationActionBuilder.setVersion(StringValue.of(subOrchestrationOptions.getVersion()));
+                }
+            } else if (this.getDefaultVersion() != null) {
+                // If the options are not of the correct type, we still allow the version to be set
+                createSubOrchestrationActionBuilder.setVersion(StringValue.of(this.getDefaultVersion()));
+            }
 
             TaskFactory<V> taskFactory = () -> {
                 int id = this.sequenceNumber++;

--- a/client/src/main/java/com/microsoft/durabletask/util/VersionUtils.java
+++ b/client/src/main/java/com/microsoft/durabletask/util/VersionUtils.java
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.util;
+
+public class VersionUtils {
+
+    /**
+     * Compares two version strings. We manually attempt to parse the version strings as a Version object
+     * was not introduced until Java 9 and we compile as far back as Java 8.
+     */
+    public static int compareVersions(String v1, String v2) {
+        if (v1 == null && v2 == null) {
+            return 0;
+        }
+        if (v1 == null) {
+            return -1;
+        }
+        if (v2 == null) {
+            return 1;
+        }
+
+        // We're looking for a dot-separated version string, e.g. "1.0.0".
+        // This can contain strings and falls back to string comparison if that is the case.
+        String[] parts1 = v1.split("\\.");
+        String[] parts2 = v2.split("\\.");
+
+        int length = Math.max(parts1.length, parts2.length);
+        for (int i = 0; i < length; i++) {
+            String part1 = i < parts1.length ? parts1[i] : "";
+            String part2 = i < parts2.length ? parts2[i] : "";
+            
+            // Try to parse as integers first
+            Integer num1 = tryParseInt(part1);
+            Integer num2 = tryParseInt(part2);
+            
+            if (num1 != null && num2 != null) {
+                // Both are numeric, compare as integers
+                if (!num1.equals(num2)) {
+                    return num1 - num2;
+                }
+            } else if (num1 != null) {
+                // part1 is numeric, part2 is not - numeric versions come before non-numeric
+                return 1;
+            } else if (num2 != null) {
+                // part2 is numeric, part1 is not - numeric versions come before non-numeric
+                return -1;
+            } else {
+                // Both are non-numeric, compare as strings
+                int stringComparison = part1.compareTo(part2);
+                if (stringComparison != 0) {
+                    return stringComparison;
+                }
+            }
+        }
+
+        return 0; // All parts are equal
+    }
+
+    private static Integer tryParseInt(String part) {
+        try {
+            return Integer.parseInt(part);
+        } catch (NumberFormatException e) {
+            return null; // indicates non-numeric part
+        }
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/util/VersionUtils.java
+++ b/client/src/main/java/com/microsoft/durabletask/util/VersionUtils.java
@@ -19,41 +19,60 @@ public class VersionUtils {
             return 1;
         }
 
-        // We're looking for a dot-separated version string, e.g. "1.0.0".
-        // This can contain strings and falls back to string comparison if that is the case.
-        String[] parts1 = v1.split("\\.");
-        String[] parts2 = v2.split("\\.");
+        // Check if both versions are in standard format (e.g., "1.0.0")
+        boolean isV1Standard = isStandardVersionString(v1);
+        boolean isV2Standard = isStandardVersionString(v2);
+        
+        // If both versions were successfully normalized, compare them as structured versions
+        if (isV1Standard && isV2Standard) {
+            return compareStandardVersions(v1, v2);
+        }
+        
+        // If either version couldn't be normalized, fall back to string comparison
+        return v1.compareTo(v2);
+    }
 
-        int length = Math.max(parts1.length, parts2.length);
-        for (int i = 0; i < length; i++) {
-            String part1 = i < parts1.length ? parts1[i] : "";
-            String part2 = i < parts2.length ? parts2[i] : "";
-            
-            // Try to parse as integers first
-            Integer num1 = tryParseInt(part1);
-            Integer num2 = tryParseInt(part2);
-            
-            if (num1 != null && num2 != null) {
-                // Both are numeric, compare as integers
-                if (!num1.equals(num2)) {
-                    return num1 - num2;
-                }
-            } else if (num1 != null) {
-                // part1 is numeric, part2 is not - numeric versions come before non-numeric
-                return 1;
-            } else if (num2 != null) {
-                // part2 is numeric, part1 is not - numeric versions come before non-numeric
-                return -1;
-            } else {
-                // Both are non-numeric, compare as strings
-                int stringComparison = part1.compareTo(part2);
-                if (stringComparison != 0) {
-                    return stringComparison;
-                }
+    /**
+     * Checks if the version string is in a standard format (e.g., "1.0.0").
+     * @param version The version string to check
+     * @return true if the version is in standard format, false otherwise
+     */
+    private static boolean isStandardVersionString(String version) {
+        if (version == null || version.trim().isEmpty()) {
+            return false;
+        }
+        
+        String[] parts = version.split("\\.");
+        
+        // Check if all parts are numeric
+        for (String part : parts) {
+            if (tryParseInt(part) == null) {
+                return false; // Contains non-numeric part, cannot normalize
             }
         }
+        return true;
+    }
 
-        return 0; // All parts are equal
+    /**
+     * Compares two standard version strings part by part.
+     * @param v1 First standard version string
+     * @param v2 Second standard version string
+     * @return Negative if v1 < v2, positive if v1 > v2, zero if equal
+     */
+    private static int compareStandardVersions(String v1, String v2) {
+        String[] parts1 = v1.split("\\.");
+        String[] parts2 = v2.split("\\.");
+        
+        int length = Math.max(parts1.length, parts2.length);
+        for (int i = 0; i < length; i++) {
+            int p1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
+            int p2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
+            if (p1 != p2) {
+                return p1 - p2;
+            }
+        }
+        
+        return 0;
     }
 
     private static Integer tryParseInt(String part) {

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTestBase.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTestBase.java
@@ -114,5 +114,10 @@ public class IntegrationTestBase {
             });
             return this;
         }
+
+        public TestDurableTaskWorkerBuilder useVersioning(DurableTaskGrpcWorkerVersioningOptions options) {
+            this.innerBuilder.useVersioning(options);
+            return this;
+        }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

This commit adds the versioning feature from the dotnet SDK (durabletask-dotnet). This allows for the version to be passed via the context and for the worker to reject/fail orchestrations based on the provided version.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information