### PR TITLE
Fixing gRPC channel shutdown

### DIFF
--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -71,11 +71,16 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     public void close() {
         if (this.managedSidecarChannel != null) {
             try {
-                this.managedSidecarChannel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+                if (!this.managedSidecarChannel.shutdown().awaitTermination(5, TimeUnit.SECONDS))
+                {
+                    this.managedSidecarChannel.shutdownNow();
+                }
             } catch (InterruptedException e) {
                 // Best effort. Also note that AutoClose documentation recommends NOT having
                 // close() methods throw InterruptedException:
                 // https://docs.oracle.com/javase/7/docs/api/java/lang/AutoCloseable.html
+                this.managedSidecarChannel.shutdownNow();
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This PR addresses an issue where a customer is running into an error when attempting to start a new orchestration:

`Previous channel ManagedChannelImpl{logId=57, target=localhost:4001} was not shutdown properly!!!`

The stack trace indicates that this occurs when attempting to build a new `managedSideCarChannel` in the `DurableTaskGrpcClient`. It appears that the previous `managedSidecarChannel` was not disposed properly in a call to `close()`. This can happen since we do nothing if the channel is not successfully terminated via a graceful call to `shutdown()` within the `timeout` (5 seconds). It can also happen if an `InterruptedException` is thrown, since we don't attempt any shutdown in that case.

To fix this, this PR initiates a forceful shutdown if the graceful shutdown fails in the timeframe. It also initiates a forceful shutdown in the case of an `InterruptedException` (but manually sets the thread's state to "interrupted" so that we do not lose this information). 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information