### PR TITLE
Pass --skipApiVersionCheck to Azurite to unblock e2e and sample tests

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -155,7 +155,11 @@ jobs:
   functions-e2e-tests:
 
     needs: build
-    runs-on: ubuntu-latest
+    # Pinned to ubuntu-22.04 as a diagnostic: ubuntu-24.04 runner image bumped from
+    # 20260513.135 (last green CI on 5/19) to 20260518.149 (first red on 5/22)
+    # with no code change in between. If this job goes green on 22.04, the regression
+    # is in the new 24.04 runner image (Docker-Buildx 0.34 / Node 20 removal / kernel).
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -180,6 +184,18 @@ jobs:
         run: endtoendtests/e2e-test-setup.ps1 -DockerfilePath endtoendtests/Dockerfile
         shell: pwsh
 
+      - name: Diagnose host readiness (always run)
+        if: always()
+        run: |
+          echo '--- docker ps ---'
+          docker ps -a
+          echo '--- curl /admin/host/ping ---'
+          curl -sv -X POST http://localhost:8080/admin/host/ping || true
+          echo '--- curl /api/StartOrchestration ---'
+          curl -sv -X POST http://localhost:8080/api/StartOrchestration || true
+          echo '--- docker logs app (tail) ---'
+          docker logs app 2>&1 | tail -200 || true
+
       - name: End to End Tests with Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -194,7 +210,8 @@ jobs:
   functions-sample-tests:
 
     needs: build
-    runs-on: ubuntu-latest
+    # Pinned to ubuntu-22.04; see comment on functions-e2e-tests.
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -155,11 +155,7 @@ jobs:
   functions-e2e-tests:
 
     needs: build
-    # Pinned to ubuntu-22.04 as a diagnostic: ubuntu-24.04 runner image bumped from
-    # 20260513.135 (last green CI on 5/19) to 20260518.149 (first red on 5/22)
-    # with no code change in between. If this job goes green on 22.04, the regression
-    # is in the new 24.04 runner image (Docker-Buildx 0.34 / Node 20 removal / kernel).
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -184,18 +180,6 @@ jobs:
         run: endtoendtests/e2e-test-setup.ps1 -DockerfilePath endtoendtests/Dockerfile
         shell: pwsh
 
-      - name: Diagnose host readiness (always run)
-        if: always()
-        run: |
-          echo '--- docker ps ---'
-          docker ps -a
-          echo '--- curl /admin/host/ping ---'
-          curl -sv -X POST http://localhost:8080/admin/host/ping || true
-          echo '--- curl /api/StartOrchestration ---'
-          curl -sv -X POST http://localhost:8080/api/StartOrchestration || true
-          echo '--- docker logs app (tail) ---'
-          docker logs app 2>&1 | tail -200 || true
-
       - name: End to End Tests with Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -210,8 +194,7 @@ jobs:
   functions-sample-tests:
 
     needs: build
-    # Pinned to ubuntu-22.04; see comment on functions-e2e-tests.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/endtoendtests/e2e-test-setup.ps1
+++ b/endtoendtests/e2e-test-setup.ps1
@@ -23,9 +23,11 @@ if ($NoSetup -eq $false) {
 	docker pull "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
 
 	Write-Host "Starting Azurite storage emulator using default ports..." -ForegroundColor Yellow
-	# --skipApiVersionCheck: client sends an x-ms-version newer than this pinned Azurite image
-	# recognizes; without this flag Azurite returns "The API version <date> is not supported by
-	# Azurite", the task hub fails to initialize, and every /api/* call returns HTTP 500.
+	# --skipApiVersionCheck: the Durable extension's Azure Storage client can request a
+	# newer REST API version than the pinned Azurite image supports (e.g. 2026-02-06 vs
+	# Azurite 3.34.0's max 2025-05-05). Without this flag, Azurite rejects the request
+	# with "The API version <date> is not supported by Azurite", the extension fails to
+	# create its task hub, and every /api/* call returns HTTP 500.
 	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}" `
 		azurite -l /workspace -d /workspace/debug.log --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 

--- a/endtoendtests/e2e-test-setup.ps1
+++ b/endtoendtests/e2e-test-setup.ps1
@@ -23,7 +23,12 @@ if ($NoSetup -eq $false) {
 	docker pull "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
 
 	Write-Host "Starting Azurite storage emulator using default ports..." -ForegroundColor Yellow
-	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
+	# --skipApiVersionCheck: the Functions host's Durable extension is updated to use newer
+	# Azure Storage REST API versions faster than Azurite releases support them. Without this
+	# flag, Azurite rejects the request with "The API version <date> is not supported by Azurite",
+	# the extension fails to create its task hub, and every /api/* call returns HTTP 500.
+	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}" `
+		azurite -l /workspace -d /workspace/debug.log --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 
 	# Finally, start up the smoke test container, which will connect to the Azurite container
 	docker run --name $ContainerName -p 8080:80 -it --add-host=host.docker.internal:host-gateway -d `

--- a/endtoendtests/e2e-test-setup.ps1
+++ b/endtoendtests/e2e-test-setup.ps1
@@ -23,10 +23,9 @@ if ($NoSetup -eq $false) {
 	docker pull "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
 
 	Write-Host "Starting Azurite storage emulator using default ports..." -ForegroundColor Yellow
-	# --skipApiVersionCheck: the Functions host's Durable extension is updated to use newer
-	# Azure Storage REST API versions faster than Azurite releases support them. Without this
-	# flag, Azurite rejects the request with "The API version <date> is not supported by Azurite",
-	# the extension fails to create its task hub, and every /api/* call returns HTTP 500.
+	# --skipApiVersionCheck: client sends an x-ms-version newer than this pinned Azurite image
+	# recognizes; without this flag Azurite returns "The API version <date> is not supported by
+	# Azurite", the task hub fails to initialize, and every /api/* call returns HTTP 500.
 	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}" `
 		azurite -l /workspace -d /workspace/debug.log --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 

--- a/samples-azure-functions/e2e-test-setup.ps1
+++ b/samples-azure-functions/e2e-test-setup.ps1
@@ -23,9 +23,11 @@ if ($NoSetup -eq $false) {
 	docker pull "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
 
 	Write-Host "Starting Azurite storage emulator using default ports..." -ForegroundColor Yellow
-	# --skipApiVersionCheck: client sends an x-ms-version newer than this pinned Azurite image
-	# recognizes; without this flag Azurite returns "The API version <date> is not supported by
-	# Azurite", the task hub fails to initialize, and every /api/* call returns HTTP 500.
+	# --skipApiVersionCheck: the Durable extension's Azure Storage client can request a
+	# newer REST API version than the pinned Azurite image supports (e.g. 2026-02-06 vs
+	# Azurite 3.34.0's max 2025-05-05). Without this flag, Azurite rejects the request
+	# with "The API version <date> is not supported by Azurite", the extension fails to
+	# create its task hub, and every /api/* call returns HTTP 500.
 	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}" `
 		azurite -l /workspace -d /workspace/debug.log --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 

--- a/samples-azure-functions/e2e-test-setup.ps1
+++ b/samples-azure-functions/e2e-test-setup.ps1
@@ -23,7 +23,12 @@ if ($NoSetup -eq $false) {
 	docker pull "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
 
 	Write-Host "Starting Azurite storage emulator using default ports..." -ForegroundColor Yellow
-	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
+	# --skipApiVersionCheck: the Functions host's Durable extension is updated to use newer
+	# Azure Storage REST API versions faster than Azurite releases support them. Without this
+	# flag, Azurite rejects the request with "The API version <date> is not supported by Azurite",
+	# the extension fails to create its task hub, and every /api/* call returns HTTP 500.
+	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}" `
+		azurite -l /workspace -d /workspace/debug.log --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 
 	# Finally, start up the smoke test container, which will connect to the Azurite container
 	docker run --name $ContainerName -p 8080:80 -it --add-host=host.docker.internal:host-gateway -d `

--- a/samples-azure-functions/e2e-test-setup.ps1
+++ b/samples-azure-functions/e2e-test-setup.ps1
@@ -23,10 +23,9 @@ if ($NoSetup -eq $false) {
 	docker pull "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}"
 
 	Write-Host "Starting Azurite storage emulator using default ports..." -ForegroundColor Yellow
-	# --skipApiVersionCheck: the Functions host's Durable extension is updated to use newer
-	# Azure Storage REST API versions faster than Azurite releases support them. Without this
-	# flag, Azurite rejects the request with "The API version <date> is not supported by Azurite",
-	# the extension fails to create its task hub, and every /api/* call returns HTTP 500.
+	# --skipApiVersionCheck: client sends an x-ms-version newer than this pinned Azurite image
+	# recognizes; without this flag Azurite returns "The API version <date> is not supported by
+	# Azurite", the task hub fails to initialize, and every /api/* call returns HTTP 500.
 	docker run --name 'azurite' -p 10000:10000 -p 10001:10001 -p 10002:10002 -d "mcr.microsoft.com/azure-storage/azurite:${AzuriteVersion}" `
 		azurite -l /workspace -d /workspace/debug.log --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 


### PR DESCRIPTION
### Issue describing the changes in this PR

The CI e2e and sample test jobs (`functions-e2e-tests`, `functions-sample-tests`) have been failing on every branch — including `main` — since around 2026-05-22, with all tests failing identically on `JsonPathException` / `IllegalArgumentException`. No code change is responsible: the same `main` SHA passed on 5/19 and fails today.

Root cause (from a diagnostic step capturing `docker logs app` in CI):

> `Azure.RequestFailedException: The API version 2026-02-06 is not supported by Azurite.`

The Durable extension's Azure Storage client requests REST API version `2026-02-06`. Azurite 3.34.0 (and the latest released 3.35.0) only supports up to `2025-11-05` and rejects the request. The extension fails during task hub initialization (`AppLeaseManager.CreateContainerIfNotExistsAsync`), so every `POST /api/StartOrchestration` returns `HTTP 500` with an empty body, which the tests fail to parse as JSON — surfacing as the cascade of `JsonPathException` failures.

This PR passes `--skipApiVersionCheck` to the Azurite container in both e2e setup scripts. That's the workaround Azurite itself recommends in the error message, and it also makes the test setup resilient to future API-version bumps in the Durable extension.

Changes:
- endtoendtests/e2e-test-setup.ps1: pass `--skipApiVersionCheck` to Azurite (alongside the image's default args).
- samples-azure-functions/e2e-test-setup.ps1: same fix.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes are added to the `CHANGELOG.md` <!-- update if not applicable -->
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Verified in CI — previously-failing E2E and sample tests now pass.