### PR TITLE
Add client APIs to list instance IDs and read orchestration history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Add client APIs to list terminal instance IDs by completion time (`listInstanceIds`) and read orchestration history (`getOrchestrationHistory`) ([#292](https://github.com/microsoft/durabletask-java/pull/292))
 * Add `getParentInstance()` API to `TaskOrchestrationContext` for discovering parent orchestration info ([#284](https://github.com/microsoft/durabletask-java/pull/284))
 
 ## v1.9.0

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -248,13 +248,15 @@ public abstract class DurableTaskClient implements AutoCloseable {
     }
 
     /**
-     * Gets the full history of an orchestration instance as an ordered list of {@link HistoryEvent} objects.
+     * Retrieves the history of the specified orchestration instance as a list of {@link HistoryEvent} objects.
      * <p>
      * The events are returned in execution order. This is useful for archiving or offline analysis of an instance's
      * execution history. Use {@code instanceof} to inspect each concrete event type.
      *
-     * @param instanceId the unique ID of the orchestration instance whose history to fetch
-     * @return the instance's history events in order; empty if the instance has no history
+     * @param instanceId the instance ID of the orchestration
+     * @return the list of {@link HistoryEvent} objects representing the orchestration's history, in execution order;
+     *         empty if the instance has no history
+     * @throws IllegalArgumentException if {@code instanceId} is null
      * @throws UnsupportedOperationException if the current client implementation does not support history retrieval
      */
     public List<HistoryEvent> getOrchestrationHistory(String instanceId) {

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -240,8 +240,12 @@ public abstract class DurableTaskClient implements AutoCloseable {
      *
      * @param query filter criteria: completion-time window, terminal runtime statuses, page size, and pagination cursor
      * @return a page of matching instance IDs and a cursor for the next page
+     * @throws UnsupportedOperationException if the current client implementation does not support listing instance IDs
      */
-    public abstract ListInstanceIdsResult listInstanceIds(ListInstanceIdsQuery query);
+    public ListInstanceIdsResult listInstanceIds(ListInstanceIdsQuery query) {
+        throw new UnsupportedOperationException(
+                "Listing instance IDs is not supported by this client implementation.");
+    }
 
     /**
      * Gets the full history of an orchestration instance as an ordered list of {@link HistoryEvent} objects.
@@ -251,8 +255,12 @@ public abstract class DurableTaskClient implements AutoCloseable {
      *
      * @param instanceId the unique ID of the orchestration instance whose history to fetch
      * @return the instance's history events in order; empty if the instance has no history
+     * @throws UnsupportedOperationException if the current client implementation does not support history retrieval
      */
-    public abstract List<HistoryEvent> getOrchestrationHistory(String instanceId);
+    public List<HistoryEvent> getOrchestrationHistory(String instanceId) {
+        throw new UnsupportedOperationException(
+                "Retrieving orchestration history is not supported by this client implementation.");
+    }
 
     /**
      * Initializes the target task hub data store.

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskClient.java
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 package com.microsoft.durabletask;
 
+import com.microsoft.durabletask.history.HistoryEvent;
+
 import javax.annotation.Nullable;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -225,6 +228,31 @@ public abstract class DurableTaskClient implements AutoCloseable {
      * @return the result of the query operation, including instance metadata and possibly a continuation token
      */
     public abstract OrchestrationStatusQueryResult queryInstances(OrchestrationStatusQuery query);
+
+    /**
+     * Lists the IDs of terminal orchestration instances that completed within a time window.
+     * <p>
+     * Unlike {@link #queryInstances(OrchestrationStatusQuery)}, which filters by creation time and returns full
+     * metadata, this method filters by <em>completion</em> time and returns only instance IDs, making it efficient
+     * for bulk enumeration such as archival/export. Results are paged; pass
+     * {@link ListInstanceIdsResult#getContinuationToken()} back via
+     * {@link ListInstanceIdsQuery#setContinuationToken(String)} to fetch subsequent pages.
+     *
+     * @param query filter criteria: completion-time window, terminal runtime statuses, page size, and pagination cursor
+     * @return a page of matching instance IDs and a cursor for the next page
+     */
+    public abstract ListInstanceIdsResult listInstanceIds(ListInstanceIdsQuery query);
+
+    /**
+     * Gets the full history of an orchestration instance as an ordered list of {@link HistoryEvent} objects.
+     * <p>
+     * The events are returned in execution order. This is useful for archiving or offline analysis of an instance's
+     * execution history. Use {@code instanceof} to inspect each concrete event type.
+     *
+     * @param instanceId the unique ID of the orchestration instance whose history to fetch
+     * @return the instance's history events in order; empty if the instance has no history
+     */
+    public abstract List<HistoryEvent> getOrchestrationHistory(String instanceId);
 
     /**
      * Initializes the target task hub data store.

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -299,6 +299,7 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
 
     @Override
     public ListInstanceIdsResult listInstanceIds(ListInstanceIdsQuery query) {
+        Helpers.throwIfArgumentNull(query, "query");
         ListInstanceIdsRequest.Builder builder = ListInstanceIdsRequest.newBuilder();
         Optional.ofNullable(query.getCompletedTimeFrom()).ifPresent(from -> builder.setCompletedTimeFrom(DataConverter.getTimestampFromInstant(from)));
         Optional.ofNullable(query.getCompletedTimeTo()).ifPresent(to -> builder.setCompletedTimeTo(DataConverter.getTimestampFromInstant(to)));
@@ -313,6 +314,7 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
 
     @Override
     public List<HistoryEvent> getOrchestrationHistory(String instanceId) {
+        Helpers.throwIfArgumentNull(instanceId, "instanceId");
         StreamInstanceHistoryRequest request = StreamInstanceHistoryRequest.newBuilder()
                 .setInstanceId(instanceId)
                 .build();

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -308,7 +308,13 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
         builder.setPageSize(query.getPageSize());
         query.getRuntimeStatusList().forEach(runtimeStatus -> Optional.ofNullable(runtimeStatus).ifPresent(status -> builder.addRuntimeStatus(OrchestrationRuntimeStatus.toProtobuf(status))));
         ListInstanceIdsResponse response = this.sidecarClient.listInstanceIds(builder.build());
-        String continuationToken = response.hasLastInstanceKey() ? response.getLastInstanceKey().getValue() : null;
+        // Treat an absent OR empty lastInstanceKey as end-of-results. A caller that loops while the
+        // continuation token is non-null would otherwise re-request with an empty cursor and restart
+        // paging from the beginning, causing an infinite loop.
+        String continuationToken =
+                response.hasLastInstanceKey() && !response.getLastInstanceKey().getValue().isEmpty()
+                        ? response.getLastInstanceKey().getValue()
+                        : null;
         return new ListInstanceIdsResult(new ArrayList<>(response.getInstanceIdsList()), continuationToken);
     }
 
@@ -319,11 +325,22 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
                 .setInstanceId(instanceId)
                 .build();
         List<HistoryEvent> historyEvents = new ArrayList<>();
-        Iterator<HistoryChunk> chunks = this.sidecarClient.streamInstanceHistory(request);
-        while (chunks.hasNext()) {
-            for (OrchestratorService.HistoryEvent protoEvent : chunks.next().getEventsList()) {
-                historyEvents.add(HistoryEventConverter.fromProto(protoEvent));
+        // Bind the server-streaming call to a cancellable context so the RPC is always released, even if
+        // draining the stream exits early via an exception. Without this, an early exit abandons the
+        // blocking iterator without cancelling the call -- a known grpc-java resource-leak pattern.
+        Context.CancellableContext streamContext = Context.current().withCancellation();
+        Context previous = streamContext.attach();
+        try {
+            Iterator<HistoryChunk> chunks = this.sidecarClient.streamInstanceHistory(request);
+            while (chunks.hasNext()) {
+                for (OrchestratorService.HistoryEvent protoEvent : chunks.next().getEventsList()) {
+                    historyEvents.add(HistoryEventConverter.fromProto(protoEvent));
+                }
             }
+        } finally {
+            streamContext.detach(previous);
+            // Cancels the RPC if it is still open (e.g. early exit mid-stream); no-op once it completed normally.
+            streamContext.cancel(null);
         }
         return historyEvents;
     }

--- a/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
+++ b/client/src/main/java/com/microsoft/durabletask/DurableTaskGrpcClient.java
@@ -4,6 +4,8 @@ package com.microsoft.durabletask;
 
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import com.microsoft.durabletask.history.HistoryEvent;
+import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.*;
 import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc;
 import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc.*;
@@ -293,6 +295,35 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
             metadataList.add(new OrchestrationMetadata(state, this.dataConverter, fetchInputsAndOutputs));
         });
         return new OrchestrationStatusQueryResult(metadataList, queryInstancesResponse.getContinuationToken().getValue());
+    }
+
+    @Override
+    public ListInstanceIdsResult listInstanceIds(ListInstanceIdsQuery query) {
+        ListInstanceIdsRequest.Builder builder = ListInstanceIdsRequest.newBuilder();
+        Optional.ofNullable(query.getCompletedTimeFrom()).ifPresent(from -> builder.setCompletedTimeFrom(DataConverter.getTimestampFromInstant(from)));
+        Optional.ofNullable(query.getCompletedTimeTo()).ifPresent(to -> builder.setCompletedTimeTo(DataConverter.getTimestampFromInstant(to)));
+        String requestContinuationToken = query.getContinuationToken() != null ? query.getContinuationToken() : "";
+        builder.setLastInstanceKey(StringValue.of(requestContinuationToken));
+        builder.setPageSize(query.getPageSize());
+        query.getRuntimeStatusList().forEach(runtimeStatus -> Optional.ofNullable(runtimeStatus).ifPresent(status -> builder.addRuntimeStatus(OrchestrationRuntimeStatus.toProtobuf(status))));
+        ListInstanceIdsResponse response = this.sidecarClient.listInstanceIds(builder.build());
+        String continuationToken = response.hasLastInstanceKey() ? response.getLastInstanceKey().getValue() : null;
+        return new ListInstanceIdsResult(new ArrayList<>(response.getInstanceIdsList()), continuationToken);
+    }
+
+    @Override
+    public List<HistoryEvent> getOrchestrationHistory(String instanceId) {
+        StreamInstanceHistoryRequest request = StreamInstanceHistoryRequest.newBuilder()
+                .setInstanceId(instanceId)
+                .build();
+        List<HistoryEvent> historyEvents = new ArrayList<>();
+        Iterator<HistoryChunk> chunks = this.sidecarClient.streamInstanceHistory(request);
+        while (chunks.hasNext()) {
+            for (OrchestratorService.HistoryEvent protoEvent : chunks.next().getEventsList()) {
+                historyEvents.add(HistoryEventConverter.fromProto(protoEvent));
+            }
+        }
+        return historyEvents;
     }
 
     @Override

--- a/client/src/main/java/com/microsoft/durabletask/EntityQueryPageable.java
+++ b/client/src/main/java/com/microsoft/durabletask/EntityQueryPageable.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
  * <p>
  * Use {@link DurableEntityClient#getAllEntities(EntityQuery)} to obtain an instance of this class.
  *
- * <h3>Example: iterate over all entities</h3>
+ * <h2>Example: iterate over all entities</h2>
  * <pre>{@code
  * EntityQuery query = new EntityQuery()
  *     .setInstanceIdStartsWith("counter")
@@ -28,7 +28,7 @@ import java.util.function.Function;
  * }
  * }</pre>
  *
- * <h3>Example: iterate page by page</h3>
+ * <h2>Example: iterate page by page</h2>
  * <pre>{@code
  * for (EntityQueryResult page : client.getEntities().getAllEntities(query).byPage()) {
  *     System.out.println("Got " + page.getEntities().size() + " entities");

--- a/client/src/main/java/com/microsoft/durabletask/HistoryEventConverter.java
+++ b/client/src/main/java/com/microsoft/durabletask/HistoryEventConverter.java
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+import com.microsoft.durabletask.history.*;
+import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * Converts protobuf {@code HistoryEvent} messages into the public {@link HistoryEvent} domain model.
+ */
+final class HistoryEventConverter {
+    private HistoryEventConverter() {
+    }
+
+    /**
+     * Converts a protobuf history event into its domain representation.
+     *
+     * @param proto the protobuf history event
+     * @return the domain {@link HistoryEvent}
+     * @throws IllegalArgumentException if the event type is not set
+     * @throws UnsupportedOperationException if the event type is not recognized
+     */
+    static HistoryEvent fromProto(OrchestratorService.HistoryEvent proto) {
+        int id = proto.getEventId();
+        Instant ts = DataConverter.getInstantFromTimestamp(proto.getTimestamp());
+        switch (proto.getEventTypeCase()) {
+            case EXECUTIONSTARTED: {
+                OrchestratorService.ExecutionStartedEvent p = proto.getExecutionStarted();
+                return new ExecutionStartedEvent(id, ts,
+                        p.getName(),
+                        stringOrNull(p.hasVersion(), p.getVersion()),
+                        stringOrNull(p.hasInput(), p.getInput()),
+                        p.hasOrchestrationInstance() ? toInstance(p.getOrchestrationInstance()) : null,
+                        p.hasParentInstance() ? toParentInfo(p.getParentInstance()) : null,
+                        p.hasScheduledStartTimestamp()
+                                ? DataConverter.getInstantFromTimestamp(p.getScheduledStartTimestamp()) : null,
+                        p.hasParentTraceContext() ? toTrace(p.getParentTraceContext()) : null,
+                        stringOrNull(p.hasOrchestrationSpanID(), p.getOrchestrationSpanID()),
+                        p.getTagsMap());
+            }
+            case EXECUTIONCOMPLETED: {
+                OrchestratorService.ExecutionCompletedEvent p = proto.getExecutionCompleted();
+                return new ExecutionCompletedEvent(id, ts,
+                        OrchestrationRuntimeStatus.fromProtobuf(p.getOrchestrationStatus()),
+                        stringOrNull(p.hasResult(), p.getResult()),
+                        p.hasFailureDetails() ? new FailureDetails(p.getFailureDetails()) : null);
+            }
+            case EXECUTIONTERMINATED: {
+                OrchestratorService.ExecutionTerminatedEvent p = proto.getExecutionTerminated();
+                return new ExecutionTerminatedEvent(id, ts, stringOrNull(p.hasInput(), p.getInput()), p.getRecurse());
+            }
+            case TASKSCHEDULED: {
+                OrchestratorService.TaskScheduledEvent p = proto.getTaskScheduled();
+                return new TaskScheduledEvent(id, ts,
+                        p.getName(),
+                        stringOrNull(p.hasVersion(), p.getVersion()),
+                        stringOrNull(p.hasInput(), p.getInput()),
+                        p.hasParentTraceContext() ? toTrace(p.getParentTraceContext()) : null,
+                        p.getTagsMap());
+            }
+            case TASKCOMPLETED: {
+                OrchestratorService.TaskCompletedEvent p = proto.getTaskCompleted();
+                return new TaskCompletedEvent(id, ts, p.getTaskScheduledId(), stringOrNull(p.hasResult(), p.getResult()));
+            }
+            case TASKFAILED: {
+                OrchestratorService.TaskFailedEvent p = proto.getTaskFailed();
+                return new TaskFailedEvent(id, ts, p.getTaskScheduledId(),
+                        p.hasFailureDetails() ? new FailureDetails(p.getFailureDetails()) : null);
+            }
+            case SUBORCHESTRATIONINSTANCECREATED: {
+                OrchestratorService.SubOrchestrationInstanceCreatedEvent p = proto.getSubOrchestrationInstanceCreated();
+                return new SubOrchestrationInstanceCreatedEvent(id, ts,
+                        p.getInstanceId(),
+                        p.getName(),
+                        stringOrNull(p.hasVersion(), p.getVersion()),
+                        stringOrNull(p.hasInput(), p.getInput()),
+                        p.hasParentTraceContext() ? toTrace(p.getParentTraceContext()) : null,
+                        p.getTagsMap());
+            }
+            case SUBORCHESTRATIONINSTANCECOMPLETED: {
+                OrchestratorService.SubOrchestrationInstanceCompletedEvent p =
+                        proto.getSubOrchestrationInstanceCompleted();
+                return new SubOrchestrationInstanceCompletedEvent(id, ts,
+                        p.getTaskScheduledId(), stringOrNull(p.hasResult(), p.getResult()));
+            }
+            case SUBORCHESTRATIONINSTANCEFAILED: {
+                OrchestratorService.SubOrchestrationInstanceFailedEvent p = proto.getSubOrchestrationInstanceFailed();
+                return new SubOrchestrationInstanceFailedEvent(id, ts, p.getTaskScheduledId(),
+                        p.hasFailureDetails() ? new FailureDetails(p.getFailureDetails()) : null);
+            }
+            case TIMERCREATED: {
+                OrchestratorService.TimerCreatedEvent p = proto.getTimerCreated();
+                return new TimerCreatedEvent(id, ts, DataConverter.getInstantFromTimestamp(p.getFireAt()));
+            }
+            case TIMERFIRED: {
+                OrchestratorService.TimerFiredEvent p = proto.getTimerFired();
+                return new TimerFiredEvent(id, ts, DataConverter.getInstantFromTimestamp(p.getFireAt()), p.getTimerId());
+            }
+            case ORCHESTRATORSTARTED:
+                return new OrchestratorStartedEvent(id, ts);
+            case ORCHESTRATORCOMPLETED:
+                return new OrchestratorCompletedEvent(id, ts);
+            case EVENTSENT: {
+                OrchestratorService.EventSentEvent p = proto.getEventSent();
+                return new EventSentEvent(id, ts, p.getInstanceId(), p.getName(),
+                        stringOrNull(p.hasInput(), p.getInput()));
+            }
+            case EVENTRAISED: {
+                OrchestratorService.EventRaisedEvent p = proto.getEventRaised();
+                return new EventRaisedEvent(id, ts, p.getName(), stringOrNull(p.hasInput(), p.getInput()));
+            }
+            case GENERICEVENT: {
+                OrchestratorService.GenericEvent p = proto.getGenericEvent();
+                return new GenericEvent(id, ts, stringOrNull(p.hasData(), p.getData()));
+            }
+            case HISTORYSTATE: {
+                OrchestratorService.HistoryStateEvent p = proto.getHistoryState();
+                return new HistoryStateEvent(id, ts,
+                        p.hasOrchestrationState() ? toOrchestrationState(p.getOrchestrationState()) : null);
+            }
+            case CONTINUEASNEW: {
+                OrchestratorService.ContinueAsNewEvent p = proto.getContinueAsNew();
+                return new ContinueAsNewEvent(id, ts, stringOrNull(p.hasInput(), p.getInput()));
+            }
+            case EXECUTIONSUSPENDED: {
+                OrchestratorService.ExecutionSuspendedEvent p = proto.getExecutionSuspended();
+                return new ExecutionSuspendedEvent(id, ts, stringOrNull(p.hasInput(), p.getInput()));
+            }
+            case EXECUTIONRESUMED: {
+                OrchestratorService.ExecutionResumedEvent p = proto.getExecutionResumed();
+                return new ExecutionResumedEvent(id, ts, stringOrNull(p.hasInput(), p.getInput()));
+            }
+            case ENTITYOPERATIONSIGNALED: {
+                OrchestratorService.EntityOperationSignaledEvent p = proto.getEntityOperationSignaled();
+                return new EntityOperationSignaledEvent(id, ts,
+                        p.getRequestId(),
+                        p.getOperation(),
+                        p.hasScheduledTime() ? DataConverter.getInstantFromTimestamp(p.getScheduledTime()) : null,
+                        stringOrNull(p.hasInput(), p.getInput()),
+                        stringOrNull(p.hasTargetInstanceId(), p.getTargetInstanceId()));
+            }
+            case ENTITYOPERATIONCALLED: {
+                OrchestratorService.EntityOperationCalledEvent p = proto.getEntityOperationCalled();
+                return new EntityOperationCalledEvent(id, ts,
+                        p.getRequestId(),
+                        p.getOperation(),
+                        p.hasScheduledTime() ? DataConverter.getInstantFromTimestamp(p.getScheduledTime()) : null,
+                        stringOrNull(p.hasInput(), p.getInput()),
+                        stringOrNull(p.hasParentInstanceId(), p.getParentInstanceId()),
+                        stringOrNull(p.hasParentExecutionId(), p.getParentExecutionId()),
+                        stringOrNull(p.hasTargetInstanceId(), p.getTargetInstanceId()));
+            }
+            case ENTITYOPERATIONCOMPLETED: {
+                OrchestratorService.EntityOperationCompletedEvent p = proto.getEntityOperationCompleted();
+                return new EntityOperationCompletedEvent(id, ts, p.getRequestId(),
+                        stringOrNull(p.hasOutput(), p.getOutput()));
+            }
+            case ENTITYOPERATIONFAILED: {
+                OrchestratorService.EntityOperationFailedEvent p = proto.getEntityOperationFailed();
+                return new EntityOperationFailedEvent(id, ts, p.getRequestId(),
+                        p.hasFailureDetails() ? new FailureDetails(p.getFailureDetails()) : null);
+            }
+            case ENTITYLOCKREQUESTED: {
+                OrchestratorService.EntityLockRequestedEvent p = proto.getEntityLockRequested();
+                return new EntityLockRequestedEvent(id, ts,
+                        p.getCriticalSectionId(),
+                        p.getLockSetList(),
+                        p.getPosition(),
+                        stringOrNull(p.hasParentInstanceId(), p.getParentInstanceId()));
+            }
+            case ENTITYLOCKGRANTED: {
+                OrchestratorService.EntityLockGrantedEvent p = proto.getEntityLockGranted();
+                return new EntityLockGrantedEvent(id, ts, p.getCriticalSectionId());
+            }
+            case ENTITYUNLOCKSENT: {
+                OrchestratorService.EntityUnlockSentEvent p = proto.getEntityUnlockSent();
+                return new EntityUnlockSentEvent(id, ts,
+                        p.getCriticalSectionId(),
+                        stringOrNull(p.hasParentInstanceId(), p.getParentInstanceId()),
+                        stringOrNull(p.hasTargetInstanceId(), p.getTargetInstanceId()));
+            }
+            case EXECUTIONREWOUND: {
+                OrchestratorService.ExecutionRewoundEvent p = proto.getExecutionRewound();
+                return new ExecutionRewoundEvent(id, ts,
+                        stringOrNull(p.hasReason(), p.getReason()),
+                        stringOrNull(p.hasParentExecutionId(), p.getParentExecutionId()),
+                        stringOrNull(p.hasInstanceId(), p.getInstanceId()),
+                        p.hasParentTraceContext() ? toTrace(p.getParentTraceContext()) : null,
+                        stringOrNull(p.hasName(), p.getName()),
+                        stringOrNull(p.hasVersion(), p.getVersion()),
+                        stringOrNull(p.hasInput(), p.getInput()),
+                        p.hasParentInstance() ? toParentInfo(p.getParentInstance()) : null,
+                        p.getTagsMap());
+            }
+            case EVENTTYPE_NOT_SET:
+                throw new IllegalArgumentException("History event does not have an eventType set.");
+            default:
+                throw new UnsupportedOperationException(
+                        "Deserialization of history event type " + proto.getEventTypeCase() + " is not supported.");
+        }
+    }
+
+    @Nullable
+    private static String stringOrNull(boolean present, com.google.protobuf.StringValue value) {
+        return present ? value.getValue() : null;
+    }
+
+    private static OrchestrationInstance toInstance(OrchestratorService.OrchestrationInstance p) {
+        return new OrchestrationInstance(p.getInstanceId(), stringOrNull(p.hasExecutionId(), p.getExecutionId()));
+    }
+
+    private static ParentInstanceInfo toParentInfo(OrchestratorService.ParentInstanceInfo p) {
+        return new ParentInstanceInfo(
+                p.getTaskScheduledId(),
+                stringOrNull(p.hasName(), p.getName()),
+                stringOrNull(p.hasVersion(), p.getVersion()),
+                p.hasOrchestrationInstance() ? toInstance(p.getOrchestrationInstance()) : null);
+    }
+
+    private static TraceContext toTrace(OrchestratorService.TraceContext p) {
+        return new TraceContext(p.getTraceParent(), stringOrNull(p.hasTraceState(), p.getTraceState()));
+    }
+
+    private static OrchestrationState toOrchestrationState(OrchestratorService.OrchestrationState p) {
+        return new OrchestrationState(
+                p.getInstanceId(),
+                p.getName(),
+                stringOrNull(p.hasVersion(), p.getVersion()),
+                OrchestrationRuntimeStatus.fromProtobuf(p.getOrchestrationStatus()),
+                p.hasScheduledStartTimestamp()
+                        ? DataConverter.getInstantFromTimestamp(p.getScheduledStartTimestamp()) : null,
+                p.hasCreatedTimestamp() ? DataConverter.getInstantFromTimestamp(p.getCreatedTimestamp()) : null,
+                p.hasLastUpdatedTimestamp() ? DataConverter.getInstantFromTimestamp(p.getLastUpdatedTimestamp()) : null,
+                p.hasCompletedTimestamp() ? DataConverter.getInstantFromTimestamp(p.getCompletedTimestamp()) : null,
+                stringOrNull(p.hasInput(), p.getInput()),
+                stringOrNull(p.hasOutput(), p.getOutput()),
+                stringOrNull(p.hasCustomStatus(), p.getCustomStatus()),
+                p.hasFailureDetails() ? new FailureDetails(p.getFailureDetails()) : null,
+                stringOrNull(p.hasExecutionId(), p.getExecutionId()),
+                stringOrNull(p.hasParentInstanceId(), p.getParentInstanceId()),
+                p.getTagsMap());
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
+++ b/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
@@ -36,7 +36,7 @@ public final class ListInstanceIdsQuery {
      * @return this query object
      */
     public ListInstanceIdsQuery setRuntimeStatusList(@Nullable List<OrchestrationRuntimeStatus> runtimeStatusList) {
-        this.runtimeStatusList = runtimeStatusList;
+        this.runtimeStatusList = runtimeStatusList != null ? new ArrayList<>(runtimeStatusList) : new ArrayList<>();
         return this;
     }
 

--- a/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
+++ b/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
@@ -68,10 +68,14 @@ public final class ListInstanceIdsQuery {
      * A page may contain fewer IDs than the page size even when more results exist; always use
      * {@link ListInstanceIdsResult#getContinuationToken()} to determine whether to continue paging.
      *
-     * @param pageSize the maximum number of instance IDs to return per page
+     * @param pageSize the maximum number of instance IDs to return per page; must be greater than zero
      * @return this query object
+     * @throws IllegalArgumentException if {@code pageSize} is less than 1
      */
     public ListInstanceIdsQuery setPageSize(int pageSize) {
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("pageSize must be at least 1.");
+        }
         this.pageSize = pageSize;
         return this;
     }

--- a/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
+++ b/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
@@ -5,6 +5,7 @@ package com.microsoft.durabletask;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -93,26 +94,46 @@ public final class ListInstanceIdsQuery {
         return this;
     }
 
-    List<OrchestrationRuntimeStatus> getRuntimeStatusList() {
-        return this.runtimeStatusList;
+    /**
+     * Gets the configured terminal runtime status filter, or an empty list if none was configured.
+     * @return an unmodifiable view of the configured terminal runtime status filter
+     */
+    public List<OrchestrationRuntimeStatus> getRuntimeStatusList() {
+        return Collections.unmodifiableList(this.runtimeStatusList);
     }
 
+    /**
+     * Gets the configured minimum completion time, or {@code null} if none was configured.
+     * @return the configured minimum completion time, or {@code null} if none was configured
+     */
     @Nullable
-    Instant getCompletedTimeFrom() {
+    public Instant getCompletedTimeFrom() {
         return this.completedTimeFrom;
     }
 
+    /**
+     * Gets the configured maximum completion time, or {@code null} if none was configured.
+     * @return the configured maximum completion time, or {@code null} if none was configured
+     */
     @Nullable
-    Instant getCompletedTimeTo() {
+    public Instant getCompletedTimeTo() {
         return this.completedTimeTo;
     }
 
-    int getPageSize() {
+    /**
+     * Gets the configured maximum number of instance IDs to return per page.
+     * @return the configured page size
+     */
+    public int getPageSize() {
         return this.pageSize;
     }
 
+    /**
+     * Gets the configured pagination cursor, or {@code null} if none was configured.
+     * @return the configured pagination cursor, or {@code null} if none was configured
+     */
     @Nullable
-    String getContinuationToken() {
+    public String getContinuationToken() {
         return this.continuationToken;
     }
 }

--- a/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
+++ b/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsQuery.java
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Query for listing terminal orchestration instance IDs by completion-time window.
+ * <p>
+ * Used with {@link DurableTaskClient#listInstanceIds(ListInstanceIdsQuery)} to enumerate the IDs of orchestration
+ * instances that reached a terminal state within a completion-time window. Unlike {@link OrchestrationStatusQuery}
+ * (which filters by creation time and returns full metadata), this query filters by <em>completion</em> time and
+ * returns only instance IDs, making it efficient for bulk enumeration such as archival/export.
+ */
+public final class ListInstanceIdsQuery {
+    private List<OrchestrationRuntimeStatus> runtimeStatusList = new ArrayList<>();
+    private Instant completedTimeFrom;
+    private Instant completedTimeTo;
+    private int pageSize = 100;
+    private String continuationToken;
+
+    /**
+     * Sole constructor.
+     */
+    public ListInstanceIdsQuery() {
+    }
+
+    /**
+     * Sets the terminal runtime status values to filter by. Only instances with a matching status are returned.
+     * The default empty list disables runtime-status filtering.
+     *
+     * @param runtimeStatusList the terminal runtime statuses to filter by (e.g. COMPLETED, FAILED, TERMINATED)
+     * @return this query object
+     */
+    public ListInstanceIdsQuery setRuntimeStatusList(@Nullable List<OrchestrationRuntimeStatus> runtimeStatusList) {
+        this.runtimeStatusList = runtimeStatusList;
+        return this;
+    }
+
+    /**
+     * Includes instances that completed at or after the specified instant.
+     *
+     * @param completedTimeFrom the minimum completion time, or {@code null} to disable this filter
+     * @return this query object
+     */
+    public ListInstanceIdsQuery setCompletedTimeFrom(@Nullable Instant completedTimeFrom) {
+        this.completedTimeFrom = completedTimeFrom;
+        return this;
+    }
+
+    /**
+     * Includes instances that completed before the specified instant.
+     *
+     * @param completedTimeTo the maximum completion time, or {@code null} to disable this filter
+     * @return this query object
+     */
+    public ListInstanceIdsQuery setCompletedTimeTo(@Nullable Instant completedTimeTo) {
+        this.completedTimeTo = completedTimeTo;
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of instance IDs to return per page. The default value is 100.
+     * <p>
+     * A page may contain fewer IDs than the page size even when more results exist; always use
+     * {@link ListInstanceIdsResult#getContinuationToken()} to determine whether to continue paging.
+     *
+     * @param pageSize the maximum number of instance IDs to return per page
+     * @return this query object
+     */
+    public ListInstanceIdsQuery setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+        return this;
+    }
+
+    /**
+     * Sets the pagination cursor used to continue listing from a previous page.
+     * <p>
+     * This should be the {@link ListInstanceIdsResult#getContinuationToken()} value from the previous page.
+     *
+     * @param continuationToken the cursor from the previous page, or {@code null} to start from the beginning
+     * @return this query object
+     */
+    public ListInstanceIdsQuery setContinuationToken(@Nullable String continuationToken) {
+        this.continuationToken = continuationToken;
+        return this;
+    }
+
+    List<OrchestrationRuntimeStatus> getRuntimeStatusList() {
+        return this.runtimeStatusList;
+    }
+
+    @Nullable
+    Instant getCompletedTimeFrom() {
+        return this.completedTimeFrom;
+    }
+
+    @Nullable
+    Instant getCompletedTimeTo() {
+        return this.completedTimeTo;
+    }
+
+    int getPageSize() {
+        return this.pageSize;
+    }
+
+    @Nullable
+    String getContinuationToken() {
+        return this.continuationToken;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsResult.java
+++ b/client/src/main/java/com/microsoft/durabletask/ListInstanceIdsResult.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result of a {@link DurableTaskClient#listInstanceIds(ListInstanceIdsQuery)} call.
+ * <p>
+ * Contains a page of terminal orchestration instance IDs and a pagination cursor for fetching the next page.
+ */
+public final class ListInstanceIdsResult {
+    private final List<String> instanceIds;
+    private final String continuationToken;
+
+    ListInstanceIdsResult(List<String> instanceIds, @Nullable String continuationToken) {
+        this.instanceIds = Collections.unmodifiableList(instanceIds);
+        this.continuationToken = continuationToken;
+    }
+
+    /**
+     * Gets the page of terminal orchestration instance IDs that matched the query.
+     *
+     * @return an unmodifiable list of instance IDs that matched the query
+     */
+    public List<String> getInstanceIds() {
+        return this.instanceIds;
+    }
+
+    /**
+     * Gets the pagination cursor to pass to the next
+     * {@link DurableTaskClient#listInstanceIds(ListInstanceIdsQuery)} call via
+     * {@link ListInstanceIdsQuery#setContinuationToken(String)}, or {@code null} when there are no more pages.
+     *
+     * @return the cursor for the next page, or {@code null} if no more pages are available
+     */
+    @Nullable
+    public String getContinuationToken() {
+        return this.continuationToken;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/TypedEntityMetadata.java
+++ b/client/src/main/java/com/microsoft/durabletask/TypedEntityMetadata.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
  * and provides a typed {@code State} property. In Java, the state is eagerly deserialized and accessible
  * via {@link #getState()}.
  *
- * <h3>Example:</h3>
+ * <h2>Example:</h2>
  * <pre>{@code
  * TypedEntityMetadata<Integer> metadata = client.getEntities()
  *     .getEntityMetadata(entityId, Integer.class);

--- a/client/src/main/java/com/microsoft/durabletask/TypedEntityQueryPageable.java
+++ b/client/src/main/java/com/microsoft/durabletask/TypedEntityQueryPageable.java
@@ -14,7 +14,7 @@ import java.util.NoSuchElementException;
  * <p>
  * Use {@link DurableEntityClient#getAllEntities(EntityQuery, Class)} to obtain an instance.
  *
- * <h3>Example:</h3>
+ * <h2>Example:</h2>
  * <pre>{@code
  * EntityQuery query = new EntityQuery().setInstanceIdStartsWith("counter");
  * for (TypedEntityMetadata<Integer> entity : client.getEntities().getAllEntities(query, Integer.class)) {

--- a/client/src/main/java/com/microsoft/durabletask/history/ContinueAsNewEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ContinueAsNewEvent.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an orchestration restarts itself via continue-as-new.
+ */
+public final class ContinueAsNewEvent extends HistoryEvent {
+    private final String input;
+
+    /**
+     * Creates a new {@code ContinueAsNewEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param input     the serialized input for the new generation, or {@code null}
+     */
+    public ContinueAsNewEvent(int eventId, Instant timestamp, @Nullable String input) {
+        super(eventId, timestamp);
+        this.input = input;
+    }
+
+    /** @return the serialized input for the new generation, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityLockGrantedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityLockGrantedEvent.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import java.time.Instant;
+
+/**
+ * History event recorded when a requested entity lock is granted.
+ */
+public final class EntityLockGrantedEvent extends HistoryEvent {
+    private final String criticalSectionId;
+
+    /**
+     * Creates a new {@code EntityLockGrantedEvent}.
+     *
+     * @param eventId           the event sequence ID
+     * @param timestamp         the event timestamp
+     * @param criticalSectionId the ID of the critical section whose lock was granted
+     */
+    public EntityLockGrantedEvent(int eventId, Instant timestamp, String criticalSectionId) {
+        super(eventId, timestamp);
+        this.criticalSectionId = criticalSectionId;
+    }
+
+    /** @return the ID of the critical section whose lock was granted. */
+    public String getCriticalSectionId() {
+        return this.criticalSectionId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityLockRequestedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityLockRequestedEvent.java
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * History event recorded when an orchestration requests a lock over one or more durable entities.
+ */
+public final class EntityLockRequestedEvent extends HistoryEvent {
+    private final String criticalSectionId;
+    private final List<String> lockSet;
+    private final int position;
+    private final String parentInstanceId;
+
+    /**
+     * Creates a new {@code EntityLockRequestedEvent}.
+     *
+     * @param eventId           the event sequence ID
+     * @param timestamp         the event timestamp
+     * @param criticalSectionId the ID of the critical section associated with the lock request
+     * @param lockSet           the ordered set of entity instance IDs being locked, or {@code null}
+     * @param position          the position of this entity within the lock set
+     * @param parentInstanceId  the requesting instance ID, or {@code null}
+     */
+    public EntityLockRequestedEvent(
+            int eventId,
+            Instant timestamp,
+            String criticalSectionId,
+            @Nullable List<String> lockSet,
+            int position,
+            @Nullable String parentInstanceId) {
+        super(eventId, timestamp);
+        this.criticalSectionId = criticalSectionId;
+        this.lockSet = lockSet != null
+                ? Collections.unmodifiableList(new ArrayList<>(lockSet)) : Collections.emptyList();
+        this.position = position;
+        this.parentInstanceId = parentInstanceId;
+    }
+
+    /** @return the ID of the critical section associated with the lock request. */
+    public String getCriticalSectionId() {
+        return this.criticalSectionId;
+    }
+
+    /** @return the ordered set of entity instance IDs being locked (never {@code null}). */
+    public List<String> getLockSet() {
+        return this.lockSet;
+    }
+
+    /** @return the position of this entity within the lock set. */
+    public int getPosition() {
+        return this.position;
+    }
+
+    /** @return the requesting instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getParentInstanceId() {
+        return this.parentInstanceId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityOperationCalledEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityOperationCalledEvent.java
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a two-way (call) operation is sent to a durable entity.
+ */
+public final class EntityOperationCalledEvent extends HistoryEvent {
+    private final String requestId;
+    private final String operation;
+    private final Instant scheduledTime;
+    private final String input;
+    private final String parentInstanceId;
+    private final String parentExecutionId;
+    private final String targetInstanceId;
+
+    /**
+     * Creates a new {@code EntityOperationCalledEvent}.
+     *
+     * @param eventId           the event sequence ID
+     * @param timestamp         the event timestamp
+     * @param requestId         the unique request ID of the entity operation
+     * @param operation         the name of the entity operation
+     * @param scheduledTime     the scheduled delivery time, or {@code null}
+     * @param input             the serialized operation input, or {@code null}
+     * @param parentInstanceId  the calling instance ID, or {@code null}
+     * @param parentExecutionId the calling execution ID, or {@code null}
+     * @param targetInstanceId  the target entity instance ID, or {@code null}
+     */
+    public EntityOperationCalledEvent(
+            int eventId,
+            Instant timestamp,
+            String requestId,
+            String operation,
+            @Nullable Instant scheduledTime,
+            @Nullable String input,
+            @Nullable String parentInstanceId,
+            @Nullable String parentExecutionId,
+            @Nullable String targetInstanceId) {
+        super(eventId, timestamp);
+        this.requestId = requestId;
+        this.operation = operation;
+        this.scheduledTime = scheduledTime;
+        this.input = input;
+        this.parentInstanceId = parentInstanceId;
+        this.parentExecutionId = parentExecutionId;
+        this.targetInstanceId = targetInstanceId;
+    }
+
+    /** @return the unique request ID of the entity operation. */
+    public String getRequestId() {
+        return this.requestId;
+    }
+
+    /** @return the name of the entity operation. */
+    public String getOperation() {
+        return this.operation;
+    }
+
+    /** @return the scheduled delivery time, or {@code null} if delivered immediately. */
+    @Nullable
+    public Instant getScheduledTime() {
+        return this.scheduledTime;
+    }
+
+    /** @return the serialized operation input, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the calling instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getParentInstanceId() {
+        return this.parentInstanceId;
+    }
+
+    /** @return the calling execution ID, or {@code null} if not set. */
+    @Nullable
+    public String getParentExecutionId() {
+        return this.parentExecutionId;
+    }
+
+    /** @return the target entity instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getTargetInstanceId() {
+        return this.targetInstanceId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityOperationCompletedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityOperationCompletedEvent.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a durable entity operation completes successfully.
+ */
+public final class EntityOperationCompletedEvent extends HistoryEvent {
+    private final String requestId;
+    private final String output;
+
+    /**
+     * Creates a new {@code EntityOperationCompletedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param requestId the unique request ID of the entity operation
+     * @param output    the serialized operation output, or {@code null}
+     */
+    public EntityOperationCompletedEvent(
+            int eventId, Instant timestamp, String requestId, @Nullable String output) {
+        super(eventId, timestamp);
+        this.requestId = requestId;
+        this.output = output;
+    }
+
+    /** @return the unique request ID of the entity operation. */
+    public String getRequestId() {
+        return this.requestId;
+    }
+
+    /** @return the serialized operation output, or {@code null} if none. */
+    @Nullable
+    public String getOutput() {
+        return this.output;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityOperationFailedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityOperationFailedEvent.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import com.microsoft.durabletask.FailureDetails;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a durable entity operation fails.
+ */
+public final class EntityOperationFailedEvent extends HistoryEvent {
+    private final String requestId;
+    private final FailureDetails failureDetails;
+
+    /**
+     * Creates a new {@code EntityOperationFailedEvent}.
+     *
+     * @param eventId        the event sequence ID
+     * @param timestamp      the event timestamp
+     * @param requestId      the unique request ID of the entity operation
+     * @param failureDetails the failure details, or {@code null}
+     */
+    public EntityOperationFailedEvent(
+            int eventId, Instant timestamp, String requestId, @Nullable FailureDetails failureDetails) {
+        super(eventId, timestamp);
+        this.requestId = requestId;
+        this.failureDetails = failureDetails;
+    }
+
+    /** @return the unique request ID of the entity operation. */
+    public String getRequestId() {
+        return this.requestId;
+    }
+
+    /** @return the failure details, or {@code null} if not available. */
+    @Nullable
+    public FailureDetails getFailureDetails() {
+        return this.failureDetails;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityOperationSignaledEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityOperationSignaledEvent.java
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a one-way (signal) operation is sent to a durable entity.
+ */
+public final class EntityOperationSignaledEvent extends HistoryEvent {
+    private final String requestId;
+    private final String operation;
+    private final Instant scheduledTime;
+    private final String input;
+    private final String targetInstanceId;
+
+    /**
+     * Creates a new {@code EntityOperationSignaledEvent}.
+     *
+     * @param eventId          the event sequence ID
+     * @param timestamp        the event timestamp
+     * @param requestId        the unique request ID of the entity operation
+     * @param operation        the name of the entity operation
+     * @param scheduledTime    the scheduled delivery time, or {@code null}
+     * @param input            the serialized operation input, or {@code null}
+     * @param targetInstanceId the target entity instance ID, or {@code null}
+     */
+    public EntityOperationSignaledEvent(
+            int eventId,
+            Instant timestamp,
+            String requestId,
+            String operation,
+            @Nullable Instant scheduledTime,
+            @Nullable String input,
+            @Nullable String targetInstanceId) {
+        super(eventId, timestamp);
+        this.requestId = requestId;
+        this.operation = operation;
+        this.scheduledTime = scheduledTime;
+        this.input = input;
+        this.targetInstanceId = targetInstanceId;
+    }
+
+    /** @return the unique request ID of the entity operation. */
+    public String getRequestId() {
+        return this.requestId;
+    }
+
+    /** @return the name of the entity operation. */
+    public String getOperation() {
+        return this.operation;
+    }
+
+    /** @return the scheduled delivery time, or {@code null} if delivered immediately. */
+    @Nullable
+    public Instant getScheduledTime() {
+        return this.scheduledTime;
+    }
+
+    /** @return the serialized operation input, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the target entity instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getTargetInstanceId() {
+        return this.targetInstanceId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EntityUnlockSentEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EntityUnlockSentEvent.java
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an entity lock is released (unlock sent).
+ */
+public final class EntityUnlockSentEvent extends HistoryEvent {
+    private final String criticalSectionId;
+    private final String parentInstanceId;
+    private final String targetInstanceId;
+
+    /**
+     * Creates a new {@code EntityUnlockSentEvent}.
+     *
+     * @param eventId           the event sequence ID
+     * @param timestamp         the event timestamp
+     * @param criticalSectionId the ID of the critical section being released
+     * @param parentInstanceId  the releasing instance ID, or {@code null}
+     * @param targetInstanceId  the target entity instance ID, or {@code null}
+     */
+    public EntityUnlockSentEvent(
+            int eventId,
+            Instant timestamp,
+            String criticalSectionId,
+            @Nullable String parentInstanceId,
+            @Nullable String targetInstanceId) {
+        super(eventId, timestamp);
+        this.criticalSectionId = criticalSectionId;
+        this.parentInstanceId = parentInstanceId;
+        this.targetInstanceId = targetInstanceId;
+    }
+
+    /** @return the ID of the critical section being released. */
+    public String getCriticalSectionId() {
+        return this.criticalSectionId;
+    }
+
+    /** @return the releasing instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getParentInstanceId() {
+        return this.parentInstanceId;
+    }
+
+    /** @return the target entity instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getTargetInstanceId() {
+        return this.targetInstanceId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EventRaisedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EventRaisedEvent.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an external event is delivered to an orchestration instance.
+ */
+public final class EventRaisedEvent extends HistoryEvent {
+    private final String name;
+    private final String input;
+
+    /**
+     * Creates a new {@code EventRaisedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param name      the name of the event
+     * @param input     the serialized event payload, or {@code null}
+     */
+    public EventRaisedEvent(int eventId, Instant timestamp, String name, @Nullable String input) {
+        super(eventId, timestamp);
+        this.name = name;
+        this.input = input;
+    }
+
+    /** @return the name of the event. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the serialized event payload, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/EventSentEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/EventSentEvent.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an orchestration sends an external event to another instance.
+ */
+public final class EventSentEvent extends HistoryEvent {
+    private final String instanceId;
+    private final String name;
+    private final String input;
+
+    /**
+     * Creates a new {@code EventSentEvent}.
+     *
+     * @param eventId    the event sequence ID
+     * @param timestamp  the event timestamp
+     * @param instanceId the target instance ID the event was sent to
+     * @param name       the name of the event
+     * @param input      the serialized event payload, or {@code null}
+     */
+    public EventSentEvent(int eventId, Instant timestamp, String instanceId, String name, @Nullable String input) {
+        super(eventId, timestamp);
+        this.instanceId = instanceId;
+        this.name = name;
+        this.input = input;
+    }
+
+    /** @return the target instance ID the event was sent to. */
+    public String getInstanceId() {
+        return this.instanceId;
+    }
+
+    /** @return the name of the event. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the serialized event payload, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ExecutionCompletedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ExecutionCompletedEvent.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import com.microsoft.durabletask.FailureDetails;
+import com.microsoft.durabletask.OrchestrationRuntimeStatus;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an orchestration instance reaches a terminal state.
+ */
+public final class ExecutionCompletedEvent extends HistoryEvent {
+    private final OrchestrationRuntimeStatus orchestrationStatus;
+    private final String result;
+    private final FailureDetails failureDetails;
+
+    /**
+     * Creates a new {@code ExecutionCompletedEvent}.
+     *
+     * @param eventId             the event sequence ID
+     * @param timestamp           the event timestamp
+     * @param orchestrationStatus the terminal runtime status
+     * @param result              the serialized orchestration output, or {@code null}
+     * @param failureDetails      the failure details if the orchestration failed, or {@code null}
+     */
+    public ExecutionCompletedEvent(
+            int eventId,
+            Instant timestamp,
+            OrchestrationRuntimeStatus orchestrationStatus,
+            @Nullable String result,
+            @Nullable FailureDetails failureDetails) {
+        super(eventId, timestamp);
+        this.orchestrationStatus = orchestrationStatus;
+        this.result = result;
+        this.failureDetails = failureDetails;
+    }
+
+    /** @return the terminal runtime status of the orchestration. */
+    public OrchestrationRuntimeStatus getOrchestrationStatus() {
+        return this.orchestrationStatus;
+    }
+
+    /** @return the serialized orchestration output, or {@code null} if none. */
+    @Nullable
+    public String getResult() {
+        return this.result;
+    }
+
+    /** @return the failure details if the orchestration failed, otherwise {@code null}. */
+    @Nullable
+    public FailureDetails getFailureDetails() {
+        return this.failureDetails;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ExecutionResumedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ExecutionResumedEvent.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a suspended orchestration instance is resumed.
+ */
+public final class ExecutionResumedEvent extends HistoryEvent {
+    private final String input;
+
+    /**
+     * Creates a new {@code ExecutionResumedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param input     the serialized resume reason, or {@code null}
+     */
+    public ExecutionResumedEvent(int eventId, Instant timestamp, @Nullable String input) {
+        super(eventId, timestamp);
+        this.input = input;
+    }
+
+    /** @return the serialized resume reason, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ExecutionRewoundEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ExecutionRewoundEvent.java
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * History event recorded when an orchestration instance is rewound to a previous good state.
+ */
+public final class ExecutionRewoundEvent extends HistoryEvent {
+    private final String reason;
+    private final String parentExecutionId;
+    private final String instanceId;
+    private final TraceContext parentTraceContext;
+    private final String name;
+    private final String version;
+    private final String input;
+    private final ParentInstanceInfo parentInstance;
+    private final Map<String, String> tags;
+
+    /**
+     * Creates a new {@code ExecutionRewoundEvent}.
+     *
+     * @param eventId            the event sequence ID
+     * @param timestamp          the event timestamp
+     * @param reason             the reason for the rewind, or {@code null}
+     * @param parentExecutionId  the parent execution ID (sub-orchestration rewind only), or {@code null}
+     * @param instanceId         the instance ID (sub-orchestration rewind only), or {@code null}
+     * @param parentTraceContext the parent distributed-tracing context, or {@code null}
+     * @param name               the orchestrator name, or {@code null}
+     * @param version            the orchestrator version, or {@code null}
+     * @param input              the serialized input, or {@code null}
+     * @param parentInstance     the parent orchestration info, or {@code null}
+     * @param tags               the orchestration tags, or {@code null}
+     */
+    public ExecutionRewoundEvent(
+            int eventId,
+            Instant timestamp,
+            @Nullable String reason,
+            @Nullable String parentExecutionId,
+            @Nullable String instanceId,
+            @Nullable TraceContext parentTraceContext,
+            @Nullable String name,
+            @Nullable String version,
+            @Nullable String input,
+            @Nullable ParentInstanceInfo parentInstance,
+            @Nullable Map<String, String> tags) {
+        super(eventId, timestamp);
+        this.reason = reason;
+        this.parentExecutionId = parentExecutionId;
+        this.instanceId = instanceId;
+        this.parentTraceContext = parentTraceContext;
+        this.name = name;
+        this.version = version;
+        this.input = input;
+        this.parentInstance = parentInstance;
+        this.tags = tags != null ? Collections.unmodifiableMap(new HashMap<>(tags)) : Collections.emptyMap();
+    }
+
+    /** @return the reason for the rewind, or {@code null} if none. */
+    @Nullable
+    public String getReason() {
+        return this.reason;
+    }
+
+    /** @return the parent execution ID (sub-orchestration rewind only), or {@code null}. */
+    @Nullable
+    public String getParentExecutionId() {
+        return this.parentExecutionId;
+    }
+
+    /** @return the instance ID (sub-orchestration rewind only), or {@code null}. */
+    @Nullable
+    public String getInstanceId() {
+        return this.instanceId;
+    }
+
+    /** @return the parent distributed-tracing context, or {@code null} if not set. */
+    @Nullable
+    public TraceContext getParentTraceContext() {
+        return this.parentTraceContext;
+    }
+
+    /** @return the orchestrator name, or {@code null} if not set. */
+    @Nullable
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the orchestrator version, or {@code null} if not set. */
+    @Nullable
+    public String getVersion() {
+        return this.version;
+    }
+
+    /** @return the serialized input, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the parent orchestration info, or {@code null} if not set. */
+    @Nullable
+    public ParentInstanceInfo getParentInstance() {
+        return this.parentInstance;
+    }
+
+    /** @return the orchestration tags (never {@code null}; empty when none). */
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ExecutionStartedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ExecutionStartedEvent.java
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * History event recorded when an orchestration instance begins execution.
+ */
+public final class ExecutionStartedEvent extends HistoryEvent {
+    private final String name;
+    private final String version;
+    private final String input;
+    private final OrchestrationInstance orchestrationInstance;
+    private final ParentInstanceInfo parentInstance;
+    private final Instant scheduledStartTimestamp;
+    private final TraceContext parentTraceContext;
+    private final String orchestrationSpanId;
+    private final Map<String, String> tags;
+
+    /**
+     * Creates a new {@code ExecutionStartedEvent}.
+     *
+     * @param eventId                 the event sequence ID
+     * @param timestamp               the event timestamp
+     * @param name                    the orchestrator name
+     * @param version                 the orchestrator version, or {@code null}
+     * @param input                   the serialized orchestration input, or {@code null}
+     * @param orchestrationInstance   the orchestration instance, or {@code null}
+     * @param parentInstance          the parent orchestration info, or {@code null}
+     * @param scheduledStartTimestamp the scheduled start time for delayed starts, or {@code null}
+     * @param parentTraceContext      the parent distributed-tracing context, or {@code null}
+     * @param orchestrationSpanId     the orchestration's tracing span ID, or {@code null}
+     * @param tags                    the orchestration tags, or {@code null}
+     */
+    public ExecutionStartedEvent(
+            int eventId,
+            Instant timestamp,
+            String name,
+            @Nullable String version,
+            @Nullable String input,
+            @Nullable OrchestrationInstance orchestrationInstance,
+            @Nullable ParentInstanceInfo parentInstance,
+            @Nullable Instant scheduledStartTimestamp,
+            @Nullable TraceContext parentTraceContext,
+            @Nullable String orchestrationSpanId,
+            @Nullable Map<String, String> tags) {
+        super(eventId, timestamp);
+        this.name = name;
+        this.version = version;
+        this.input = input;
+        this.orchestrationInstance = orchestrationInstance;
+        this.parentInstance = parentInstance;
+        this.scheduledStartTimestamp = scheduledStartTimestamp;
+        this.parentTraceContext = parentTraceContext;
+        this.orchestrationSpanId = orchestrationSpanId;
+        this.tags = tags != null ? Collections.unmodifiableMap(new HashMap<>(tags)) : Collections.emptyMap();
+    }
+
+    /** @return the name of the orchestrator. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the orchestrator version, or {@code null} if not set. */
+    @Nullable
+    public String getVersion() {
+        return this.version;
+    }
+
+    /** @return the serialized orchestration input, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the orchestration instance, or {@code null} if not set. */
+    @Nullable
+    public OrchestrationInstance getOrchestrationInstance() {
+        return this.orchestrationInstance;
+    }
+
+    /** @return the parent orchestration info if this is a sub-orchestration, otherwise {@code null}. */
+    @Nullable
+    public ParentInstanceInfo getParentInstance() {
+        return this.parentInstance;
+    }
+
+    /** @return the scheduled start time for delayed starts, or {@code null} if started immediately. */
+    @Nullable
+    public Instant getScheduledStartTimestamp() {
+        return this.scheduledStartTimestamp;
+    }
+
+    /** @return the distributed-tracing context of the parent, or {@code null} if not set. */
+    @Nullable
+    public TraceContext getParentTraceContext() {
+        return this.parentTraceContext;
+    }
+
+    /** @return the orchestration's tracing span ID, or {@code null} if not set. */
+    @Nullable
+    public String getOrchestrationSpanId() {
+        return this.orchestrationSpanId;
+    }
+
+    /** @return the orchestration tags (never {@code null}; empty when none). */
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ExecutionSuspendedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ExecutionSuspendedEvent.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an orchestration instance is suspended.
+ */
+public final class ExecutionSuspendedEvent extends HistoryEvent {
+    private final String input;
+
+    /**
+     * Creates a new {@code ExecutionSuspendedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param input     the serialized suspension reason, or {@code null}
+     */
+    public ExecutionSuspendedEvent(int eventId, Instant timestamp, @Nullable String input) {
+        super(eventId, timestamp);
+        this.input = input;
+    }
+
+    /** @return the serialized suspension reason, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ExecutionTerminatedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ExecutionTerminatedEvent.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when an orchestration instance is terminated.
+ */
+public final class ExecutionTerminatedEvent extends HistoryEvent {
+    private final String input;
+    private final boolean recurse;
+
+    /**
+     * Creates a new {@code ExecutionTerminatedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param input     the serialized termination input/reason, or {@code null}
+     * @param recurse   whether termination recurses into sub-orchestrations
+     */
+    public ExecutionTerminatedEvent(int eventId, Instant timestamp, @Nullable String input, boolean recurse) {
+        super(eventId, timestamp);
+        this.input = input;
+        this.recurse = recurse;
+    }
+
+    /** @return the serialized termination input/reason, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return whether termination recurses into sub-orchestrations. */
+    public boolean isRecurse() {
+        return this.recurse;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/GenericEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/GenericEvent.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event that carries a generic, free-form data payload.
+ */
+public final class GenericEvent extends HistoryEvent {
+    private final String data;
+
+    /**
+     * Creates a new {@code GenericEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param data      the serialized event data, or {@code null}
+     */
+    public GenericEvent(int eventId, Instant timestamp, @Nullable String data) {
+        super(eventId, timestamp);
+        this.data = data;
+    }
+
+    /** @return the serialized event data, or {@code null} if none. */
+    @Nullable
+    public String getData() {
+        return this.data;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/HistoryEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/HistoryEvent.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import java.time.Instant;
+
+/**
+ * Base class for the events that make up an orchestration instance's execution history.
+ * <p>
+ * Instances are obtained from {@link com.microsoft.durabletask.DurableTaskClient#streamInstanceHistory(String)}. Each
+ * concrete subclass (for example {@link ExecutionStartedEvent} or {@link TaskCompletedEvent}) exposes the data specific
+ * to that event type. Use {@code instanceof} to inspect the concrete event type.
+ */
+public abstract class HistoryEvent {
+    private final int eventId;
+    private final Instant timestamp;
+
+    HistoryEvent(int eventId, Instant timestamp) {
+        this.eventId = eventId;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Gets the sequence ID of this history event, or {@code -1} if the event is not associated with a specific action.
+     *
+     * @return the event sequence ID
+     */
+    public int getEventId() {
+        return this.eventId;
+    }
+
+    /**
+     * Gets the UTC timestamp at which this history event was recorded.
+     *
+     * @return the event timestamp
+     */
+    public Instant getTimestamp() {
+        return this.timestamp;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/HistoryEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/HistoryEvent.java
@@ -7,7 +7,7 @@ import java.time.Instant;
 /**
  * Base class for the events that make up an orchestration instance's execution history.
  * <p>
- * Instances are obtained from {@link com.microsoft.durabletask.DurableTaskClient#streamInstanceHistory(String)}. Each
+ * Instances are obtained from {@link com.microsoft.durabletask.DurableTaskClient#getOrchestrationHistory(String)}. Each
  * concrete subclass (for example {@link ExecutionStartedEvent} or {@link TaskCompletedEvent}) exposes the data specific
  * to that event type. Use {@code instanceof} to inspect the concrete event type.
  */

--- a/client/src/main/java/com/microsoft/durabletask/history/HistoryStateEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/HistoryStateEvent.java
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event that carries a snapshot of the orchestration's runtime state.
+ * <p>
+ * This is an internal checkpoint marker. The full state snapshot is surfaced via {@link #getState()}, matching the
+ * sibling .NET SDK ({@code HistoryStateEvent.State}) and Python SDK ({@code HistoryStateEvent.orchestration_state}).
+ */
+public final class HistoryStateEvent extends HistoryEvent {
+    private final OrchestrationState state;
+
+    /**
+     * Creates a new {@code HistoryStateEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param state     the orchestration state snapshot, or {@code null} if not available
+     */
+    public HistoryStateEvent(int eventId, Instant timestamp, @Nullable OrchestrationState state) {
+        super(eventId, timestamp);
+        this.state = state;
+    }
+
+    /** @return the orchestration state snapshot, or {@code null} if not available. */
+    @Nullable
+    public OrchestrationState getState() {
+        return this.state;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/OrchestrationInstance.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/OrchestrationInstance.java
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+
+/**
+ * Identifies an orchestration instance and, optionally, a specific execution (generation) of it.
+ */
+public final class OrchestrationInstance {
+    private final String instanceId;
+    private final String executionId;
+
+    /**
+     * Creates a new {@code OrchestrationInstance}.
+     *
+     * @param instanceId  the orchestration instance ID
+     * @param executionId the execution (generation) ID, or {@code null}
+     */
+    public OrchestrationInstance(String instanceId, @Nullable String executionId) {
+        this.instanceId = instanceId;
+        this.executionId = executionId;
+    }
+
+    /** @return the unique ID of the orchestration instance. */
+    public String getInstanceId() {
+        return this.instanceId;
+    }
+
+    /** @return the execution (generation) ID, or {@code null} if not set. */
+    @Nullable
+    public String getExecutionId() {
+        return this.executionId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/OrchestrationState.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/OrchestrationState.java
@@ -84,7 +84,7 @@ public final class OrchestrationState {
         this.failureDetails = failureDetails;
         this.executionId = executionId;
         this.parentInstanceId = parentInstanceId;
-        this.tags = tags == null ? null : Collections.unmodifiableMap(new HashMap<>(tags));
+        this.tags = tags != null ? Collections.unmodifiableMap(new HashMap<>(tags)) : Collections.emptyMap();
     }
 
     /** @return the orchestration instance ID. */
@@ -168,8 +168,7 @@ public final class OrchestrationState {
         return this.parentInstanceId;
     }
 
-    /** @return an unmodifiable view of the orchestration tags, or {@code null} if not set. */
-    @Nullable
+    /** @return the orchestration tags (never {@code null}; empty when none). */
     public Map<String, String> getTags() {
         return this.tags;
     }

--- a/client/src/main/java/com/microsoft/durabletask/history/OrchestrationState.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/OrchestrationState.java
@@ -8,6 +8,7 @@ import com.microsoft.durabletask.OrchestrationRuntimeStatus;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -83,7 +84,7 @@ public final class OrchestrationState {
         this.failureDetails = failureDetails;
         this.executionId = executionId;
         this.parentInstanceId = parentInstanceId;
-        this.tags = tags == null ? null : Collections.unmodifiableMap(tags);
+        this.tags = tags == null ? null : Collections.unmodifiableMap(new HashMap<>(tags));
     }
 
     /** @return the orchestration instance ID. */

--- a/client/src/main/java/com/microsoft/durabletask/history/OrchestrationState.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/OrchestrationState.java
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import com.microsoft.durabletask.FailureDetails;
+import com.microsoft.durabletask.OrchestrationRuntimeStatus;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A snapshot of an orchestration instance's runtime state, as carried by a {@link HistoryStateEvent}.
+ * <p>
+ * This mirrors the {@code OrchestrationState} surfaced by the sibling .NET and Python SDKs (the .NET
+ * {@code HistoryStateEvent.State} property and the Python {@code HistoryStateEvent.orchestration_state} value), so that
+ * archival/export consumers can capture the full state checkpoint rather than just the instance ID.
+ */
+public final class OrchestrationState {
+    private final String instanceId;
+    private final String name;
+    private final String version;
+    private final OrchestrationRuntimeStatus runtimeStatus;
+    private final Instant scheduledStartTime;
+    private final Instant createdTime;
+    private final Instant lastUpdatedTime;
+    private final Instant completedTime;
+    private final String input;
+    private final String output;
+    private final String customStatus;
+    private final FailureDetails failureDetails;
+    private final String executionId;
+    private final String parentInstanceId;
+    private final Map<String, String> tags;
+
+    /**
+     * Creates a new {@code OrchestrationState}.
+     *
+     * @param instanceId       the orchestration instance ID
+     * @param name             the orchestration name
+     * @param version          the orchestration version, or {@code null}
+     * @param runtimeStatus    the runtime status of the orchestration
+     * @param scheduledStartTime the scheduled start time, or {@code null}
+     * @param createdTime      the creation time, or {@code null}
+     * @param lastUpdatedTime  the last-updated time, or {@code null}
+     * @param completedTime    the completion time, or {@code null}
+     * @param input            the serialized input, or {@code null}
+     * @param output           the serialized output, or {@code null}
+     * @param customStatus     the serialized custom status, or {@code null}
+     * @param failureDetails   the failure details when the orchestration failed, or {@code null}
+     * @param executionId      the execution ID, or {@code null}
+     * @param parentInstanceId the parent instance ID, or {@code null}
+     * @param tags             the orchestration tags, or {@code null}
+     */
+    public OrchestrationState(
+            String instanceId,
+            String name,
+            @Nullable String version,
+            OrchestrationRuntimeStatus runtimeStatus,
+            @Nullable Instant scheduledStartTime,
+            @Nullable Instant createdTime,
+            @Nullable Instant lastUpdatedTime,
+            @Nullable Instant completedTime,
+            @Nullable String input,
+            @Nullable String output,
+            @Nullable String customStatus,
+            @Nullable FailureDetails failureDetails,
+            @Nullable String executionId,
+            @Nullable String parentInstanceId,
+            @Nullable Map<String, String> tags) {
+        this.instanceId = instanceId;
+        this.name = name;
+        this.version = version;
+        this.runtimeStatus = runtimeStatus;
+        this.scheduledStartTime = scheduledStartTime;
+        this.createdTime = createdTime;
+        this.lastUpdatedTime = lastUpdatedTime;
+        this.completedTime = completedTime;
+        this.input = input;
+        this.output = output;
+        this.customStatus = customStatus;
+        this.failureDetails = failureDetails;
+        this.executionId = executionId;
+        this.parentInstanceId = parentInstanceId;
+        this.tags = tags == null ? null : Collections.unmodifiableMap(tags);
+    }
+
+    /** @return the orchestration instance ID. */
+    public String getInstanceId() {
+        return this.instanceId;
+    }
+
+    /** @return the orchestration name. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the orchestration version, or {@code null} if not set. */
+    @Nullable
+    public String getVersion() {
+        return this.version;
+    }
+
+    /** @return the runtime status of the orchestration. */
+    public OrchestrationRuntimeStatus getRuntimeStatus() {
+        return this.runtimeStatus;
+    }
+
+    /** @return the scheduled start time, or {@code null} if not set. */
+    @Nullable
+    public Instant getScheduledStartTime() {
+        return this.scheduledStartTime;
+    }
+
+    /** @return the creation time, or {@code null} if not set. */
+    @Nullable
+    public Instant getCreatedTime() {
+        return this.createdTime;
+    }
+
+    /** @return the last-updated time, or {@code null} if not set. */
+    @Nullable
+    public Instant getLastUpdatedTime() {
+        return this.lastUpdatedTime;
+    }
+
+    /** @return the completion time, or {@code null} if not set. */
+    @Nullable
+    public Instant getCompletedTime() {
+        return this.completedTime;
+    }
+
+    /** @return the serialized orchestration input, or {@code null} if not set. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the serialized orchestration output, or {@code null} if not set. */
+    @Nullable
+    public String getOutput() {
+        return this.output;
+    }
+
+    /** @return the serialized custom status, or {@code null} if not set. */
+    @Nullable
+    public String getCustomStatus() {
+        return this.customStatus;
+    }
+
+    /** @return the failure details when the orchestration failed, or {@code null} otherwise. */
+    @Nullable
+    public FailureDetails getFailureDetails() {
+        return this.failureDetails;
+    }
+
+    /** @return the execution ID, or {@code null} if not set. */
+    @Nullable
+    public String getExecutionId() {
+        return this.executionId;
+    }
+
+    /** @return the parent instance ID, or {@code null} if not set. */
+    @Nullable
+    public String getParentInstanceId() {
+        return this.parentInstanceId;
+    }
+
+    /** @return an unmodifiable view of the orchestration tags, or {@code null} if not set. */
+    @Nullable
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/OrchestratorCompletedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/OrchestratorCompletedEvent.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import java.time.Instant;
+
+/**
+ * History event recorded at the end of each orchestration replay/episode. Carries no payload.
+ */
+public final class OrchestratorCompletedEvent extends HistoryEvent {
+    /**
+     * Creates a new {@code OrchestratorCompletedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     */
+    public OrchestratorCompletedEvent(int eventId, Instant timestamp) {
+        super(eventId, timestamp);
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/OrchestratorStartedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/OrchestratorStartedEvent.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import java.time.Instant;
+
+/**
+ * History event recorded at the start of each orchestration replay/episode. Carries no payload.
+ */
+public final class OrchestratorStartedEvent extends HistoryEvent {
+    /**
+     * Creates a new {@code OrchestratorStartedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     */
+    public OrchestratorStartedEvent(int eventId, Instant timestamp) {
+        super(eventId, timestamp);
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/ParentInstanceInfo.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/ParentInstanceInfo.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+
+/**
+ * Information about the parent orchestration that created a sub-orchestration.
+ */
+public final class ParentInstanceInfo {
+    private final int taskScheduledId;
+    private final String name;
+    private final String version;
+    private final OrchestrationInstance orchestrationInstance;
+
+    /**
+     * Creates a new {@code ParentInstanceInfo}.
+     *
+     * @param taskScheduledId       the task scheduled ID of the sub-orchestration in the parent's history
+     * @param name                  the parent orchestrator name, or {@code null}
+     * @param version               the parent orchestrator version, or {@code null}
+     * @param orchestrationInstance the parent orchestration instance, or {@code null}
+     */
+    public ParentInstanceInfo(
+            int taskScheduledId,
+            @Nullable String name,
+            @Nullable String version,
+            @Nullable OrchestrationInstance orchestrationInstance) {
+        this.taskScheduledId = taskScheduledId;
+        this.name = name;
+        this.version = version;
+        this.orchestrationInstance = orchestrationInstance;
+    }
+
+    /** @return the task scheduled ID of the sub-orchestration in the parent's history. */
+    public int getTaskScheduledId() {
+        return this.taskScheduledId;
+    }
+
+    /** @return the parent orchestrator name, or {@code null} if not set. */
+    @Nullable
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the parent orchestrator version, or {@code null} if not set. */
+    @Nullable
+    public String getVersion() {
+        return this.version;
+    }
+
+    /** @return the parent orchestration instance, or {@code null} if not set. */
+    @Nullable
+    public OrchestrationInstance getOrchestrationInstance() {
+        return this.orchestrationInstance;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/SubOrchestrationInstanceCompletedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/SubOrchestrationInstanceCompletedEvent.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a sub-orchestration instance completes successfully.
+ */
+public final class SubOrchestrationInstanceCompletedEvent extends HistoryEvent {
+    private final int taskScheduledId;
+    private final String result;
+
+    /**
+     * Creates a new {@code SubOrchestrationInstanceCompletedEvent}.
+     *
+     * @param eventId         the event sequence ID
+     * @param timestamp       the event timestamp
+     * @param taskScheduledId the event ID of the corresponding {@link SubOrchestrationInstanceCreatedEvent}
+     * @param result          the serialized sub-orchestration result, or {@code null}
+     */
+    public SubOrchestrationInstanceCompletedEvent(
+            int eventId, Instant timestamp, int taskScheduledId, @Nullable String result) {
+        super(eventId, timestamp);
+        this.taskScheduledId = taskScheduledId;
+        this.result = result;
+    }
+
+    /** @return the event ID of the corresponding {@link SubOrchestrationInstanceCreatedEvent}. */
+    public int getTaskScheduledId() {
+        return this.taskScheduledId;
+    }
+
+    /** @return the serialized sub-orchestration result, or {@code null} if none. */
+    @Nullable
+    public String getResult() {
+        return this.result;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/SubOrchestrationInstanceCreatedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/SubOrchestrationInstanceCreatedEvent.java
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * History event recorded when a sub-orchestration instance is created by an orchestration.
+ */
+public final class SubOrchestrationInstanceCreatedEvent extends HistoryEvent {
+    private final String instanceId;
+    private final String name;
+    private final String version;
+    private final String input;
+    private final TraceContext parentTraceContext;
+    private final Map<String, String> tags;
+
+    /**
+     * Creates a new {@code SubOrchestrationInstanceCreatedEvent}.
+     *
+     * @param eventId            the event sequence ID
+     * @param timestamp          the event timestamp
+     * @param instanceId         the instance ID assigned to the sub-orchestration
+     * @param name               the name of the sub-orchestrator
+     * @param version            the sub-orchestrator version, or {@code null}
+     * @param input              the serialized sub-orchestration input, or {@code null}
+     * @param parentTraceContext the parent distributed-tracing context, or {@code null}
+     * @param tags               the sub-orchestration tags, or {@code null}
+     */
+    public SubOrchestrationInstanceCreatedEvent(
+            int eventId,
+            Instant timestamp,
+            String instanceId,
+            String name,
+            @Nullable String version,
+            @Nullable String input,
+            @Nullable TraceContext parentTraceContext,
+            @Nullable Map<String, String> tags) {
+        super(eventId, timestamp);
+        this.instanceId = instanceId;
+        this.name = name;
+        this.version = version;
+        this.input = input;
+        this.parentTraceContext = parentTraceContext;
+        this.tags = tags != null ? Collections.unmodifiableMap(new HashMap<>(tags)) : Collections.emptyMap();
+    }
+
+    /** @return the instance ID assigned to the sub-orchestration. */
+    public String getInstanceId() {
+        return this.instanceId;
+    }
+
+    /** @return the name of the sub-orchestrator. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the sub-orchestrator version, or {@code null} if not set. */
+    @Nullable
+    public String getVersion() {
+        return this.version;
+    }
+
+    /** @return the serialized sub-orchestration input, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the distributed-tracing context of the parent, or {@code null} if not set. */
+    @Nullable
+    public TraceContext getParentTraceContext() {
+        return this.parentTraceContext;
+    }
+
+    /** @return the sub-orchestration tags (never {@code null}; empty when none). */
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/SubOrchestrationInstanceFailedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/SubOrchestrationInstanceFailedEvent.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import com.microsoft.durabletask.FailureDetails;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a sub-orchestration instance fails.
+ */
+public final class SubOrchestrationInstanceFailedEvent extends HistoryEvent {
+    private final int taskScheduledId;
+    private final FailureDetails failureDetails;
+
+    /**
+     * Creates a new {@code SubOrchestrationInstanceFailedEvent}.
+     *
+     * @param eventId         the event sequence ID
+     * @param timestamp       the event timestamp
+     * @param taskScheduledId the event ID of the corresponding {@link SubOrchestrationInstanceCreatedEvent}
+     * @param failureDetails  the failure details, or {@code null}
+     */
+    public SubOrchestrationInstanceFailedEvent(
+            int eventId, Instant timestamp, int taskScheduledId, @Nullable FailureDetails failureDetails) {
+        super(eventId, timestamp);
+        this.taskScheduledId = taskScheduledId;
+        this.failureDetails = failureDetails;
+    }
+
+    /** @return the event ID of the corresponding {@link SubOrchestrationInstanceCreatedEvent}. */
+    public int getTaskScheduledId() {
+        return this.taskScheduledId;
+    }
+
+    /** @return the failure details, or {@code null} if not available. */
+    @Nullable
+    public FailureDetails getFailureDetails() {
+        return this.failureDetails;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/TaskCompletedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/TaskCompletedEvent.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a scheduled activity task completes successfully.
+ */
+public final class TaskCompletedEvent extends HistoryEvent {
+    private final int taskScheduledId;
+    private final String result;
+
+    /**
+     * Creates a new {@code TaskCompletedEvent}.
+     *
+     * @param eventId         the event sequence ID
+     * @param timestamp       the event timestamp
+     * @param taskScheduledId the event ID of the corresponding {@link TaskScheduledEvent}
+     * @param result          the serialized activity result, or {@code null}
+     */
+    public TaskCompletedEvent(int eventId, Instant timestamp, int taskScheduledId, @Nullable String result) {
+        super(eventId, timestamp);
+        this.taskScheduledId = taskScheduledId;
+        this.result = result;
+    }
+
+    /** @return the event ID of the corresponding {@link TaskScheduledEvent}. */
+    public int getTaskScheduledId() {
+        return this.taskScheduledId;
+    }
+
+    /** @return the serialized activity result, or {@code null} if none. */
+    @Nullable
+    public String getResult() {
+        return this.result;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/TaskFailedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/TaskFailedEvent.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import com.microsoft.durabletask.FailureDetails;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * History event recorded when a scheduled activity task fails.
+ */
+public final class TaskFailedEvent extends HistoryEvent {
+    private final int taskScheduledId;
+    private final FailureDetails failureDetails;
+
+    /**
+     * Creates a new {@code TaskFailedEvent}.
+     *
+     * @param eventId         the event sequence ID
+     * @param timestamp       the event timestamp
+     * @param taskScheduledId the event ID of the corresponding {@link TaskScheduledEvent}
+     * @param failureDetails  the failure details, or {@code null}
+     */
+    public TaskFailedEvent(
+            int eventId, Instant timestamp, int taskScheduledId, @Nullable FailureDetails failureDetails) {
+        super(eventId, timestamp);
+        this.taskScheduledId = taskScheduledId;
+        this.failureDetails = failureDetails;
+    }
+
+    /** @return the event ID of the corresponding {@link TaskScheduledEvent}. */
+    public int getTaskScheduledId() {
+        return this.taskScheduledId;
+    }
+
+    /** @return the failure details, or {@code null} if not available. */
+    @Nullable
+    public FailureDetails getFailureDetails() {
+        return this.failureDetails;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/TaskScheduledEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/TaskScheduledEvent.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * History event recorded when an activity task is scheduled by an orchestration.
+ */
+public final class TaskScheduledEvent extends HistoryEvent {
+    private final String name;
+    private final String version;
+    private final String input;
+    private final TraceContext parentTraceContext;
+    private final Map<String, String> tags;
+
+    /**
+     * Creates a new {@code TaskScheduledEvent}.
+     *
+     * @param eventId            the event sequence ID
+     * @param timestamp          the event timestamp
+     * @param name               the name of the scheduled activity
+     * @param version            the activity version, or {@code null}
+     * @param input              the serialized activity input, or {@code null}
+     * @param parentTraceContext the parent distributed-tracing context, or {@code null}
+     * @param tags               the activity tags, or {@code null}
+     */
+    public TaskScheduledEvent(
+            int eventId,
+            Instant timestamp,
+            String name,
+            @Nullable String version,
+            @Nullable String input,
+            @Nullable TraceContext parentTraceContext,
+            @Nullable Map<String, String> tags) {
+        super(eventId, timestamp);
+        this.name = name;
+        this.version = version;
+        this.input = input;
+        this.parentTraceContext = parentTraceContext;
+        this.tags = tags != null ? Collections.unmodifiableMap(new HashMap<>(tags)) : Collections.emptyMap();
+    }
+
+    /** @return the name of the scheduled activity. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** @return the activity version, or {@code null} if not set. */
+    @Nullable
+    public String getVersion() {
+        return this.version;
+    }
+
+    /** @return the serialized activity input, or {@code null} if none. */
+    @Nullable
+    public String getInput() {
+        return this.input;
+    }
+
+    /** @return the distributed-tracing context of the parent, or {@code null} if not set. */
+    @Nullable
+    public TraceContext getParentTraceContext() {
+        return this.parentTraceContext;
+    }
+
+    /** @return the activity tags (never {@code null}; empty when none). */
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/TimerCreatedEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/TimerCreatedEvent.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import java.time.Instant;
+
+/**
+ * History event recorded when a durable timer is created by an orchestration.
+ */
+public final class TimerCreatedEvent extends HistoryEvent {
+    private final Instant fireAt;
+
+    /**
+     * Creates a new {@code TimerCreatedEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param fireAt    the time at which the timer is scheduled to fire
+     */
+    public TimerCreatedEvent(int eventId, Instant timestamp, Instant fireAt) {
+        super(eventId, timestamp);
+        this.fireAt = fireAt;
+    }
+
+    /** @return the time at which the timer is scheduled to fire. */
+    public Instant getFireAt() {
+        return this.fireAt;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/TimerFiredEvent.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/TimerFiredEvent.java
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import java.time.Instant;
+
+/**
+ * History event recorded when a durable timer fires.
+ */
+public final class TimerFiredEvent extends HistoryEvent {
+    private final Instant fireAt;
+    private final int timerId;
+
+    /**
+     * Creates a new {@code TimerFiredEvent}.
+     *
+     * @param eventId   the event sequence ID
+     * @param timestamp the event timestamp
+     * @param fireAt    the time at which the timer was scheduled to fire
+     * @param timerId   the event ID of the corresponding {@link TimerCreatedEvent}
+     */
+    public TimerFiredEvent(int eventId, Instant timestamp, Instant fireAt, int timerId) {
+        super(eventId, timestamp);
+        this.fireAt = fireAt;
+        this.timerId = timerId;
+    }
+
+    /** @return the time at which the timer was scheduled to fire. */
+    public Instant getFireAt() {
+        return this.fireAt;
+    }
+
+    /** @return the event ID of the corresponding {@link TimerCreatedEvent}. */
+    public int getTimerId() {
+        return this.timerId;
+    }
+}

--- a/client/src/main/java/com/microsoft/durabletask/history/TraceContext.java
+++ b/client/src/main/java/com/microsoft/durabletask/history/TraceContext.java
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import javax.annotation.Nullable;
+
+/**
+ * Distributed-tracing context (W3C Trace Context) associated with a history event.
+ */
+public final class TraceContext {
+    private final String traceParent;
+    private final String traceState;
+
+    /**
+     * Creates a new {@code TraceContext}.
+     *
+     * @param traceParent the W3C {@code traceparent} value
+     * @param traceState  the W3C {@code tracestate} value, or {@code null}
+     */
+    public TraceContext(String traceParent, @Nullable String traceState) {
+        this.traceParent = traceParent;
+        this.traceState = traceState;
+    }
+
+    /** @return the W3C {@code traceparent} value. */
+    public String getTraceParent() {
+        return this.traceParent;
+    }
+
+    /** @return the W3C {@code tracestate} value, or {@code null} if not set. */
+    @Nullable
+    public String getTraceState() {
+        return this.traceState;
+    }
+}

--- a/client/src/test/java/com/microsoft/durabletask/DurableTaskGrpcClientListInstanceIdsTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/DurableTaskGrpcClientListInstanceIdsTest.java
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+import com.google.protobuf.StringValue;
+import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.ListInstanceIdsRequest;
+import com.microsoft.durabletask.implementation.protobuf.OrchestratorService.ListInstanceIdsResponse;
+import com.microsoft.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link DurableTaskGrpcClient#listInstanceIds(ListInstanceIdsQuery)} pagination-token handling.
+ * <p>
+ * These tests stand up an in-process gRPC server whose {@code listInstanceIds} implementation returns a controlled
+ * {@code lastInstanceKey}, verifying that the client only surfaces a non-null continuation token when the server
+ * returns a present, non-empty key. A present-but-empty key must terminate pagination to avoid an infinite loop.
+ */
+public class DurableTaskGrpcClientListInstanceIdsTest {
+
+    private Server inProcessServer;
+    private ManagedChannel inProcessChannel;
+
+    private DurableTaskClient startClient(StringValue lastInstanceKey, boolean setKey) throws Exception {
+        String serverName = InProcessServerBuilder.generateName();
+        this.inProcessServer = InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(new TaskHubSidecarServiceGrpc.TaskHubSidecarServiceImplBase() {
+                @Override
+                public void listInstanceIds(
+                        ListInstanceIdsRequest request,
+                        StreamObserver<ListInstanceIdsResponse> responseObserver) {
+                    ListInstanceIdsResponse.Builder builder = ListInstanceIdsResponse.newBuilder()
+                        .addAllInstanceIds(Arrays.asList("instance-a", "instance-b"));
+                    if (setKey) {
+                        builder.setLastInstanceKey(lastInstanceKey);
+                    }
+                    responseObserver.onNext(builder.build());
+                    responseObserver.onCompleted();
+                }
+            })
+            .build()
+            .start();
+
+        this.inProcessChannel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        // The externally-provided channel is not owned by the client, so close() is a no-op; the channel is
+        // shut down in tearDown().
+        return new DurableTaskGrpcClientBuilder().grpcChannel(this.inProcessChannel).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (this.inProcessChannel != null) {
+            this.inProcessChannel.shutdownNow();
+        }
+        if (this.inProcessServer != null) {
+            this.inProcessServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void emptyLastInstanceKeyTerminatesPagination() throws Exception {
+        DurableTaskClient client = startClient(StringValue.of(""), true);
+        ListInstanceIdsResult result = client.listInstanceIds(new ListInstanceIdsQuery());
+
+        assertEquals(Arrays.asList("instance-a", "instance-b"), result.getInstanceIds());
+        assertNull(
+            result.getContinuationToken(),
+            "A present-but-empty lastInstanceKey must be surfaced as null so callers stop paging.");
+    }
+
+    @Test
+    void absentLastInstanceKeyTerminatesPagination() throws Exception {
+        DurableTaskClient client = startClient(null, false);
+        ListInstanceIdsResult result = client.listInstanceIds(new ListInstanceIdsQuery());
+
+        assertNull(result.getContinuationToken());
+    }
+
+    @Test
+    void nonEmptyLastInstanceKeyIsReturnedAsContinuationToken() throws Exception {
+        DurableTaskClient client = startClient(StringValue.of("instance-b"), true);
+        ListInstanceIdsResult result = client.listInstanceIds(new ListInstanceIdsQuery());
+
+        assertEquals("instance-b", result.getContinuationToken());
+    }
+}

--- a/client/src/test/java/com/microsoft/durabletask/HistoryEventConverterTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/HistoryEventConverterTest.java
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.durabletask;
+
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Timestamp;
+import com.microsoft.durabletask.history.ExecutionCompletedEvent;
+import com.microsoft.durabletask.history.ExecutionStartedEvent;
+import com.microsoft.durabletask.history.GenericEvent;
+import com.microsoft.durabletask.history.HistoryEvent;
+import com.microsoft.durabletask.history.HistoryStateEvent;
+import com.microsoft.durabletask.history.OrchestrationState;
+import com.microsoft.durabletask.history.SubOrchestrationInstanceCompletedEvent;
+import com.microsoft.durabletask.history.TaskCompletedEvent;
+import com.microsoft.durabletask.history.TaskFailedEvent;
+import com.microsoft.durabletask.history.TimerFiredEvent;
+import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link HistoryEventConverter}, which maps protobuf history events to the public
+ * {@code com.microsoft.durabletask.history} domain model.
+ */
+public class HistoryEventConverterTest {
+
+    private static final long EPOCH_SECONDS = 1_700_000_000L;
+    private static final Instant EXPECTED_TIMESTAMP = Instant.ofEpochSecond(EPOCH_SECONDS);
+
+    private static OrchestratorService.HistoryEvent.Builder baseEvent(int eventId) {
+        return OrchestratorService.HistoryEvent.newBuilder()
+                .setEventId(eventId)
+                .setTimestamp(Timestamp.newBuilder().setSeconds(EPOCH_SECONDS).build());
+    }
+
+    @Test
+    void convertsExecutionStarted() {
+        OrchestratorService.HistoryEvent proto = baseEvent(1)
+                .setExecutionStarted(OrchestratorService.ExecutionStartedEvent.newBuilder()
+                        .setName("MyOrchestration")
+                        .setVersion(StringValue.of("2.0"))
+                        .setInput(StringValue.of("\"hello\""))
+                        .setOrchestrationInstance(OrchestratorService.OrchestrationInstance.newBuilder()
+                                .setInstanceId("inst-1")
+                                .setExecutionId(StringValue.of("exec-1"))))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        ExecutionStartedEvent started = assertInstanceOf(ExecutionStartedEvent.class, event);
+        assertEquals(1, started.getEventId());
+        assertEquals(EXPECTED_TIMESTAMP, started.getTimestamp());
+        assertEquals("MyOrchestration", started.getName());
+        assertEquals("2.0", started.getVersion());
+        assertEquals("\"hello\"", started.getInput());
+        assertNotNull(started.getOrchestrationInstance());
+        assertEquals("inst-1", started.getOrchestrationInstance().getInstanceId());
+        assertEquals("exec-1", started.getOrchestrationInstance().getExecutionId());
+    }
+
+    @Test
+    void convertsExecutionCompletedWithResult() {
+        OrchestratorService.HistoryEvent proto = baseEvent(2)
+                .setExecutionCompleted(OrchestratorService.ExecutionCompletedEvent.newBuilder()
+                        .setOrchestrationStatus(OrchestratorService.OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED)
+                        .setResult(StringValue.of("\"done\"")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        ExecutionCompletedEvent completed = assertInstanceOf(ExecutionCompletedEvent.class, event);
+        assertEquals(OrchestrationRuntimeStatus.COMPLETED, completed.getOrchestrationStatus());
+        assertEquals("\"done\"", completed.getResult());
+        assertNull(completed.getFailureDetails());
+    }
+
+    @Test
+    void convertsExecutionCompletedWithFailureDetails() {
+        OrchestratorService.HistoryEvent proto = baseEvent(3)
+                .setExecutionCompleted(OrchestratorService.ExecutionCompletedEvent.newBuilder()
+                        .setOrchestrationStatus(OrchestratorService.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED)
+                        .setFailureDetails(OrchestratorService.TaskFailureDetails.newBuilder()
+                                .setErrorType("java.lang.RuntimeException")
+                                .setErrorMessage("boom")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        ExecutionCompletedEvent completed = assertInstanceOf(ExecutionCompletedEvent.class, event);
+        assertEquals(OrchestrationRuntimeStatus.FAILED, completed.getOrchestrationStatus());
+        assertNotNull(completed.getFailureDetails());
+        assertEquals("java.lang.RuntimeException", completed.getFailureDetails().getErrorType());
+        assertEquals("boom", completed.getFailureDetails().getErrorMessage());
+    }
+
+    @Test
+    void convertsTaskCompleted() {
+        OrchestratorService.HistoryEvent proto = baseEvent(4)
+                .setTaskCompleted(OrchestratorService.TaskCompletedEvent.newBuilder()
+                        .setTaskScheduledId(7)
+                        .setResult(StringValue.of("42")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        TaskCompletedEvent completed = assertInstanceOf(TaskCompletedEvent.class, event);
+        assertEquals(7, completed.getTaskScheduledId());
+        assertEquals("42", completed.getResult());
+    }
+
+    @Test
+    void convertsTaskFailedWithFailureDetails() {
+        OrchestratorService.HistoryEvent proto = baseEvent(5)
+                .setTaskFailed(OrchestratorService.TaskFailedEvent.newBuilder()
+                        .setTaskScheduledId(9)
+                        .setFailureDetails(OrchestratorService.TaskFailureDetails.newBuilder()
+                                .setErrorType("java.io.IOException")
+                                .setErrorMessage("disk full")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        TaskFailedEvent failed = assertInstanceOf(TaskFailedEvent.class, event);
+        assertEquals(9, failed.getTaskScheduledId());
+        assertNotNull(failed.getFailureDetails());
+        assertEquals("java.io.IOException", failed.getFailureDetails().getErrorType());
+    }
+
+    @Test
+    void convertsSubOrchestrationCompleted() {
+        OrchestratorService.HistoryEvent proto = baseEvent(6)
+                .setSubOrchestrationInstanceCompleted(
+                        OrchestratorService.SubOrchestrationInstanceCompletedEvent.newBuilder()
+                                .setTaskScheduledId(3)
+                                .setResult(StringValue.of("\"child-result\"")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        SubOrchestrationInstanceCompletedEvent completed =
+                assertInstanceOf(SubOrchestrationInstanceCompletedEvent.class, event);
+        assertEquals(3, completed.getTaskScheduledId());
+        assertEquals("\"child-result\"", completed.getResult());
+    }
+
+    @Test
+    void convertsTimerFired() {
+        Instant fireAt = Instant.ofEpochSecond(EPOCH_SECONDS + 60);
+        OrchestratorService.HistoryEvent proto = baseEvent(7)
+                .setTimerFired(OrchestratorService.TimerFiredEvent.newBuilder()
+                        .setTimerId(11)
+                        .setFireAt(Timestamp.newBuilder().setSeconds(fireAt.getEpochSecond()).build()))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        TimerFiredEvent fired = assertInstanceOf(TimerFiredEvent.class, event);
+        assertEquals(11, fired.getTimerId());
+        assertEquals(fireAt, fired.getFireAt());
+    }
+
+    @Test
+    void convertsGenericEvent() {
+        OrchestratorService.HistoryEvent proto = baseEvent(8)
+                .setGenericEvent(OrchestratorService.GenericEvent.newBuilder()
+                        .setData(StringValue.of("payload")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        GenericEvent generic = assertInstanceOf(GenericEvent.class, event);
+        assertEquals("payload", generic.getData());
+    }
+
+    @Test
+    void convertsHistoryStateExposesFullOrchestrationState() {
+        Instant created = Instant.ofEpochSecond(EPOCH_SECONDS - 100);
+        Instant lastUpdated = Instant.ofEpochSecond(EPOCH_SECONDS - 50);
+        OrchestratorService.HistoryEvent proto = baseEvent(9)
+                .setHistoryState(OrchestratorService.HistoryStateEvent.newBuilder()
+                        .setOrchestrationState(OrchestratorService.OrchestrationState.newBuilder()
+                                .setInstanceId("inst-9")
+                                .setName("MyOrchestration")
+                                .setVersion(StringValue.of("1.5"))
+                                .setOrchestrationStatus(
+                                        OrchestratorService.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING)
+                                .setCreatedTimestamp(Timestamp.newBuilder().setSeconds(created.getEpochSecond()))
+                                .setLastUpdatedTimestamp(
+                                        Timestamp.newBuilder().setSeconds(lastUpdated.getEpochSecond()))
+                                .setInput(StringValue.of("\"in\""))
+                                .setCustomStatus(StringValue.of("\"working\""))
+                                .putTags("env", "prod")))
+                .build();
+
+        HistoryEvent event = HistoryEventConverter.fromProto(proto);
+
+        HistoryStateEvent stateEvent = assertInstanceOf(HistoryStateEvent.class, event);
+        OrchestrationState state = stateEvent.getState();
+        assertNotNull(state);
+        assertEquals("inst-9", state.getInstanceId());
+        assertEquals("MyOrchestration", state.getName());
+        assertEquals("1.5", state.getVersion());
+        assertEquals(OrchestrationRuntimeStatus.RUNNING, state.getRuntimeStatus());
+        assertEquals(created, state.getCreatedTime());
+        assertEquals(lastUpdated, state.getLastUpdatedTime());
+        assertEquals("\"in\"", state.getInput());
+        assertEquals("\"working\"", state.getCustomStatus());
+        assertNotNull(state.getTags());
+        assertEquals("prod", state.getTags().get("env"));
+    }
+
+    @Test
+    void throwsWhenEventTypeNotSet() {
+        OrchestratorService.HistoryEvent proto = baseEvent(10).build();
+
+        assertThrows(IllegalArgumentException.class, () -> HistoryEventConverter.fromProto(proto));
+    }
+}

--- a/client/src/test/java/com/microsoft/durabletask/HistoryEventConverterTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/HistoryEventConverterTest.java
@@ -5,26 +5,48 @@ package com.microsoft.durabletask;
 
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import com.microsoft.durabletask.history.ContinueAsNewEvent;
+import com.microsoft.durabletask.history.EntityLockGrantedEvent;
+import com.microsoft.durabletask.history.EntityLockRequestedEvent;
+import com.microsoft.durabletask.history.EntityOperationCalledEvent;
+import com.microsoft.durabletask.history.EntityOperationCompletedEvent;
+import com.microsoft.durabletask.history.EntityOperationFailedEvent;
+import com.microsoft.durabletask.history.EntityOperationSignaledEvent;
+import com.microsoft.durabletask.history.EntityUnlockSentEvent;
+import com.microsoft.durabletask.history.EventRaisedEvent;
+import com.microsoft.durabletask.history.EventSentEvent;
 import com.microsoft.durabletask.history.ExecutionCompletedEvent;
+import com.microsoft.durabletask.history.ExecutionResumedEvent;
+import com.microsoft.durabletask.history.ExecutionRewoundEvent;
 import com.microsoft.durabletask.history.ExecutionStartedEvent;
+import com.microsoft.durabletask.history.ExecutionSuspendedEvent;
+import com.microsoft.durabletask.history.ExecutionTerminatedEvent;
 import com.microsoft.durabletask.history.GenericEvent;
 import com.microsoft.durabletask.history.HistoryEvent;
 import com.microsoft.durabletask.history.HistoryStateEvent;
+import com.microsoft.durabletask.history.OrchestratorCompletedEvent;
+import com.microsoft.durabletask.history.OrchestratorStartedEvent;
 import com.microsoft.durabletask.history.OrchestrationState;
+import com.microsoft.durabletask.history.SubOrchestrationInstanceCreatedEvent;
 import com.microsoft.durabletask.history.SubOrchestrationInstanceCompletedEvent;
+import com.microsoft.durabletask.history.SubOrchestrationInstanceFailedEvent;
 import com.microsoft.durabletask.history.TaskCompletedEvent;
 import com.microsoft.durabletask.history.TaskFailedEvent;
+import com.microsoft.durabletask.history.TaskScheduledEvent;
+import com.microsoft.durabletask.history.TimerCreatedEvent;
 import com.microsoft.durabletask.history.TimerFiredEvent;
 import com.microsoft.durabletask.implementation.protobuf.OrchestratorService;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link HistoryEventConverter}, which maps protobuf history events to the public
@@ -215,6 +237,366 @@ public class HistoryEventConverterTest {
         assertEquals("\"working\"", state.getCustomStatus());
         assertNotNull(state.getTags());
         assertEquals("prod", state.getTags().get("env"));
+    }
+
+    @Test
+    void convertsExecutionTerminated() {
+        OrchestratorService.HistoryEvent proto = baseEvent(11)
+                .setExecutionTerminated(OrchestratorService.ExecutionTerminatedEvent.newBuilder()
+                        .setInput(StringValue.of("\"termination reason\""))
+                        .setRecurse(true))
+                .build();
+
+        ExecutionTerminatedEvent terminated =
+                assertInstanceOf(ExecutionTerminatedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("\"termination reason\"", terminated.getInput());
+        assertTrue(terminated.isRecurse());
+    }
+
+    @Test
+    void convertsTaskScheduled() {
+        OrchestratorService.HistoryEvent proto = baseEvent(12)
+                .setTaskScheduled(OrchestratorService.TaskScheduledEvent.newBuilder()
+                        .setName("SendEmail")
+                        .setVersion(StringValue.of("v2"))
+                        .setInput(StringValue.of("\"message\""))
+                        .setParentTraceContext(OrchestratorService.TraceContext.newBuilder()
+                                .setTraceParent("trace-parent")
+                                .setTraceState(StringValue.of("trace-state")))
+                        .putTags("operation", "email"))
+                .build();
+
+        TaskScheduledEvent scheduled =
+                assertInstanceOf(TaskScheduledEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("SendEmail", scheduled.getName());
+        assertEquals("v2", scheduled.getVersion());
+        assertEquals("\"message\"", scheduled.getInput());
+        assertNotNull(scheduled.getParentTraceContext());
+        assertEquals("trace-parent", scheduled.getParentTraceContext().getTraceParent());
+        assertEquals("trace-state", scheduled.getParentTraceContext().getTraceState());
+        assertEquals("email", scheduled.getTags().get("operation"));
+    }
+
+    @Test
+    void convertsSubOrchestrationInstanceCreated() {
+        OrchestratorService.HistoryEvent proto = baseEvent(13)
+                .setSubOrchestrationInstanceCreated(
+                        OrchestratorService.SubOrchestrationInstanceCreatedEvent.newBuilder()
+                                .setInstanceId("child-instance")
+                                .setName("ChildOrchestrator")
+                                .setVersion(StringValue.of("v3"))
+                                .setInput(StringValue.of("\"child input\""))
+                                .setParentTraceContext(OrchestratorService.TraceContext.newBuilder()
+                                        .setTraceParent("child-trace-parent")
+                                        .setTraceState(StringValue.of("child-trace-state")))
+                                .putTags("source", "parent"))
+                .build();
+
+        SubOrchestrationInstanceCreatedEvent created = assertInstanceOf(
+                SubOrchestrationInstanceCreatedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("child-instance", created.getInstanceId());
+        assertEquals("ChildOrchestrator", created.getName());
+        assertEquals("v3", created.getVersion());
+        assertEquals("\"child input\"", created.getInput());
+        assertNotNull(created.getParentTraceContext());
+        assertEquals("child-trace-parent", created.getParentTraceContext().getTraceParent());
+        assertEquals("child-trace-state", created.getParentTraceContext().getTraceState());
+        assertEquals("parent", created.getTags().get("source"));
+    }
+
+    @Test
+    void convertsSubOrchestrationInstanceFailed() {
+        OrchestratorService.HistoryEvent proto = baseEvent(14)
+                .setSubOrchestrationInstanceFailed(
+                        OrchestratorService.SubOrchestrationInstanceFailedEvent.newBuilder()
+                                .setTaskScheduledId(23)
+                                .setFailureDetails(OrchestratorService.TaskFailureDetails.newBuilder()
+                                        .setErrorType("java.lang.IllegalStateException")
+                                        .setErrorMessage("child failed")))
+                .build();
+
+        SubOrchestrationInstanceFailedEvent failed = assertInstanceOf(
+                SubOrchestrationInstanceFailedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals(23, failed.getTaskScheduledId());
+        assertNotNull(failed.getFailureDetails());
+        assertEquals("java.lang.IllegalStateException", failed.getFailureDetails().getErrorType());
+        assertEquals("child failed", failed.getFailureDetails().getErrorMessage());
+    }
+
+    @Test
+    void convertsTimerCreated() {
+        Instant fireAt = Instant.ofEpochSecond(EPOCH_SECONDS + 120);
+        OrchestratorService.HistoryEvent proto = baseEvent(15)
+                .setTimerCreated(OrchestratorService.TimerCreatedEvent.newBuilder()
+                        .setFireAt(Timestamp.newBuilder().setSeconds(fireAt.getEpochSecond())))
+                .build();
+
+        TimerCreatedEvent created = assertInstanceOf(TimerCreatedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals(fireAt, created.getFireAt());
+    }
+
+    @Test
+    void convertsOrchestratorStartedAndCompleted() {
+        OrchestratorService.HistoryEvent startedProto = baseEvent(16)
+                .setOrchestratorStarted(OrchestratorService.OrchestratorStartedEvent.newBuilder())
+                .build();
+        OrchestratorService.HistoryEvent completedProto = baseEvent(17)
+                .setOrchestratorCompleted(OrchestratorService.OrchestratorCompletedEvent.newBuilder())
+                .build();
+
+        OrchestratorStartedEvent started =
+                assertInstanceOf(OrchestratorStartedEvent.class, HistoryEventConverter.fromProto(startedProto));
+        OrchestratorCompletedEvent completed =
+                assertInstanceOf(OrchestratorCompletedEvent.class, HistoryEventConverter.fromProto(completedProto));
+
+        assertEquals(16, started.getEventId());
+        assertEquals(EXPECTED_TIMESTAMP, started.getTimestamp());
+        assertEquals(17, completed.getEventId());
+        assertEquals(EXPECTED_TIMESTAMP, completed.getTimestamp());
+    }
+
+    @Test
+    void convertsEventSent() {
+        OrchestratorService.HistoryEvent proto = baseEvent(18)
+                .setEventSent(OrchestratorService.EventSentEvent.newBuilder()
+                        .setInstanceId("target-instance")
+                        .setName("ApprovalReceived")
+                        .setInput(StringValue.of("true")))
+                .build();
+
+        EventSentEvent sent = assertInstanceOf(EventSentEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("target-instance", sent.getInstanceId());
+        assertEquals("ApprovalReceived", sent.getName());
+        assertEquals("true", sent.getInput());
+    }
+
+    @Test
+    void convertsEventRaised() {
+        OrchestratorService.HistoryEvent proto = baseEvent(19)
+                .setEventRaised(OrchestratorService.EventRaisedEvent.newBuilder()
+                        .setName("ApprovalReceived")
+                        .setInput(StringValue.of("true")))
+                .build();
+
+        EventRaisedEvent raised = assertInstanceOf(EventRaisedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("ApprovalReceived", raised.getName());
+        assertEquals("true", raised.getInput());
+    }
+
+    @Test
+    void convertsContinueAsNew() {
+        OrchestratorService.HistoryEvent proto = baseEvent(20)
+                .setContinueAsNew(OrchestratorService.ContinueAsNewEvent.newBuilder()
+                        .setInput(StringValue.of("\"next generation\"")))
+                .build();
+
+        ContinueAsNewEvent continued =
+                assertInstanceOf(ContinueAsNewEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("\"next generation\"", continued.getInput());
+    }
+
+    @Test
+    void convertsExecutionSuspendedAndResumed() {
+        OrchestratorService.HistoryEvent suspendedProto = baseEvent(21)
+                .setExecutionSuspended(OrchestratorService.ExecutionSuspendedEvent.newBuilder()
+                        .setInput(StringValue.of("\"maintenance\"")))
+                .build();
+        OrchestratorService.HistoryEvent resumedProto = baseEvent(22)
+                .setExecutionResumed(OrchestratorService.ExecutionResumedEvent.newBuilder()
+                        .setInput(StringValue.of("\"maintenance complete\"")))
+                .build();
+
+        ExecutionSuspendedEvent suspended =
+                assertInstanceOf(ExecutionSuspendedEvent.class, HistoryEventConverter.fromProto(suspendedProto));
+        ExecutionResumedEvent resumed =
+                assertInstanceOf(ExecutionResumedEvent.class, HistoryEventConverter.fromProto(resumedProto));
+
+        assertEquals("\"maintenance\"", suspended.getInput());
+        assertEquals("\"maintenance complete\"", resumed.getInput());
+    }
+
+    @Test
+    void convertsEntityOperationSignaled() {
+        Instant scheduledTime = Instant.ofEpochSecond(EPOCH_SECONDS + 180);
+        OrchestratorService.HistoryEvent proto = baseEvent(23)
+                .setEntityOperationSignaled(OrchestratorService.EntityOperationSignaledEvent.newBuilder()
+                        .setRequestId("signal-request")
+                        .setOperation("increment")
+                        .setScheduledTime(Timestamp.newBuilder().setSeconds(scheduledTime.getEpochSecond()))
+                        .setInput(StringValue.of("5"))
+                        .setTargetInstanceId(StringValue.of("@counter@one")))
+                .build();
+
+        EntityOperationSignaledEvent signaled =
+                assertInstanceOf(EntityOperationSignaledEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("signal-request", signaled.getRequestId());
+        assertEquals("increment", signaled.getOperation());
+        assertEquals(scheduledTime, signaled.getScheduledTime());
+        assertEquals("5", signaled.getInput());
+        assertEquals("@counter@one", signaled.getTargetInstanceId());
+    }
+
+    @Test
+    void convertsEntityOperationCalled() {
+        Instant scheduledTime = Instant.ofEpochSecond(EPOCH_SECONDS + 240);
+        OrchestratorService.HistoryEvent proto = baseEvent(24)
+                .setEntityOperationCalled(OrchestratorService.EntityOperationCalledEvent.newBuilder()
+                        .setRequestId("call-request")
+                        .setOperation("get")
+                        .setScheduledTime(Timestamp.newBuilder().setSeconds(scheduledTime.getEpochSecond()))
+                        .setInput(StringValue.of("\"key\""))
+                        .setParentInstanceId(StringValue.of("parent-instance"))
+                        .setParentExecutionId(StringValue.of("parent-execution"))
+                        .setTargetInstanceId(StringValue.of("@store@one")))
+                .build();
+
+        EntityOperationCalledEvent called =
+                assertInstanceOf(EntityOperationCalledEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("call-request", called.getRequestId());
+        assertEquals("get", called.getOperation());
+        assertEquals(scheduledTime, called.getScheduledTime());
+        assertEquals("\"key\"", called.getInput());
+        assertEquals("parent-instance", called.getParentInstanceId());
+        assertEquals("parent-execution", called.getParentExecutionId());
+        assertEquals("@store@one", called.getTargetInstanceId());
+    }
+
+    @Test
+    void convertsEntityOperationCompleted() {
+        OrchestratorService.HistoryEvent proto = baseEvent(25)
+                .setEntityOperationCompleted(OrchestratorService.EntityOperationCompletedEvent.newBuilder()
+                        .setRequestId("completed-request")
+                        .setOutput(StringValue.of("\"result\"")))
+                .build();
+
+        EntityOperationCompletedEvent completed =
+                assertInstanceOf(EntityOperationCompletedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("completed-request", completed.getRequestId());
+        assertEquals("\"result\"", completed.getOutput());
+    }
+
+    @Test
+    void convertsEntityOperationFailed() {
+        OrchestratorService.HistoryEvent proto = baseEvent(26)
+                .setEntityOperationFailed(OrchestratorService.EntityOperationFailedEvent.newBuilder()
+                        .setRequestId("failed-request")
+                        .setFailureDetails(OrchestratorService.TaskFailureDetails.newBuilder()
+                                .setErrorType("java.lang.IllegalArgumentException")
+                                .setErrorMessage("invalid operation")))
+                .build();
+
+        EntityOperationFailedEvent failed =
+                assertInstanceOf(EntityOperationFailedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("failed-request", failed.getRequestId());
+        assertNotNull(failed.getFailureDetails());
+        assertEquals("java.lang.IllegalArgumentException", failed.getFailureDetails().getErrorType());
+        assertEquals("invalid operation", failed.getFailureDetails().getErrorMessage());
+    }
+
+    @Test
+    void convertsEntityLockRequested() {
+        OrchestratorService.HistoryEvent proto = baseEvent(27)
+                .setEntityLockRequested(OrchestratorService.EntityLockRequestedEvent.newBuilder()
+                        .setCriticalSectionId("critical-section")
+                        .addAllLockSet(Arrays.asList("@account@one", "@account@two"))
+                        .setPosition(1)
+                        .setParentInstanceId(StringValue.of("parent-instance")))
+                .build();
+
+        EntityLockRequestedEvent requested =
+                assertInstanceOf(EntityLockRequestedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("critical-section", requested.getCriticalSectionId());
+        assertEquals(Arrays.asList("@account@one", "@account@two"), requested.getLockSet());
+        assertEquals(1, requested.getPosition());
+        assertEquals("parent-instance", requested.getParentInstanceId());
+    }
+
+    @Test
+    void convertsEntityLockGranted() {
+        OrchestratorService.HistoryEvent proto = baseEvent(28)
+                .setEntityLockGranted(OrchestratorService.EntityLockGrantedEvent.newBuilder()
+                        .setCriticalSectionId("critical-section"))
+                .build();
+
+        EntityLockGrantedEvent granted =
+                assertInstanceOf(EntityLockGrantedEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("critical-section", granted.getCriticalSectionId());
+    }
+
+    @Test
+    void convertsEntityUnlockSent() {
+        OrchestratorService.HistoryEvent proto = baseEvent(29)
+                .setEntityUnlockSent(OrchestratorService.EntityUnlockSentEvent.newBuilder()
+                        .setCriticalSectionId("critical-section")
+                        .setParentInstanceId(StringValue.of("parent-instance"))
+                        .setTargetInstanceId(StringValue.of("@account@one")))
+                .build();
+
+        EntityUnlockSentEvent unlockSent =
+                assertInstanceOf(EntityUnlockSentEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("critical-section", unlockSent.getCriticalSectionId());
+        assertEquals("parent-instance", unlockSent.getParentInstanceId());
+        assertEquals("@account@one", unlockSent.getTargetInstanceId());
+    }
+
+    @Test
+    void convertsExecutionRewound() {
+        OrchestratorService.HistoryEvent proto = baseEvent(30)
+                .setExecutionRewound(OrchestratorService.ExecutionRewoundEvent.newBuilder()
+                        .setReason(StringValue.of("retry after fix"))
+                        .setParentExecutionId(StringValue.of("parent-execution"))
+                        .setInstanceId(StringValue.of("child-instance"))
+                        .setParentTraceContext(OrchestratorService.TraceContext.newBuilder()
+                                .setTraceParent("rewind-trace-parent")
+                                .setTraceState(StringValue.of("rewind-trace-state")))
+                        .setName(StringValue.of("ChildOrchestrator"))
+                        .setVersion(StringValue.of("v4"))
+                        .setInput(StringValue.of("\"rewind input\""))
+                        .setParentInstance(OrchestratorService.ParentInstanceInfo.newBuilder()
+                                .setTaskScheduledId(31)
+                                .setName(StringValue.of("ParentOrchestrator"))
+                                .setVersion(StringValue.of("v1"))
+                                .setOrchestrationInstance(OrchestratorService.OrchestrationInstance.newBuilder()
+                                        .setInstanceId("parent-instance")
+                                        .setExecutionId(StringValue.of("parent-execution"))))
+                        .putTags("reason", "repair"))
+                .build();
+
+        ExecutionRewoundEvent rewound =
+                assertInstanceOf(ExecutionRewoundEvent.class, HistoryEventConverter.fromProto(proto));
+
+        assertEquals("retry after fix", rewound.getReason());
+        assertEquals("parent-execution", rewound.getParentExecutionId());
+        assertEquals("child-instance", rewound.getInstanceId());
+        assertNotNull(rewound.getParentTraceContext());
+        assertEquals("rewind-trace-parent", rewound.getParentTraceContext().getTraceParent());
+        assertEquals("rewind-trace-state", rewound.getParentTraceContext().getTraceState());
+        assertEquals("ChildOrchestrator", rewound.getName());
+        assertEquals("v4", rewound.getVersion());
+        assertEquals("\"rewind input\"", rewound.getInput());
+        assertNotNull(rewound.getParentInstance());
+        assertEquals(31, rewound.getParentInstance().getTaskScheduledId());
+        assertEquals("ParentOrchestrator", rewound.getParentInstance().getName());
+        assertEquals("v1", rewound.getParentInstance().getVersion());
+        assertNotNull(rewound.getParentInstance().getOrchestrationInstance());
+        assertEquals("parent-instance", rewound.getParentInstance().getOrchestrationInstance().getInstanceId());
+        assertEquals("parent-execution", rewound.getParentInstance().getOrchestrationInstance().getExecutionId());
+        assertEquals("repair", rewound.getTags().get("reason"));
     }
 
     @Test

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -14,6 +14,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.microsoft.durabletask.history.ExecutionStartedEvent;
+import com.microsoft.durabletask.history.HistoryEvent;
+import com.microsoft.durabletask.history.TaskCompletedEvent;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -1199,6 +1202,73 @@ public class IntegrationTests extends IntegrationTestBase {
         try (worker; client) {
             String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName, 0);
             assertThrows(TimeoutException.class, () -> client.waitForInstanceCompletion(instanceId, Duration.ofSeconds(2), false));
+        }
+    }
+
+    @Test
+    void listInstanceIdsByCompletionWindow() throws TimeoutException {
+        final String orchestratorName = "ListInstanceIdsExport";
+        final String plusOne = "PlusOne";
+
+        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
+                .addOrchestrator(orchestratorName, ctx -> {
+                    int value = ctx.getInput(int.class);
+                    value = ctx.callActivity(plusOne, value, int.class).await();
+                    ctx.complete(value);
+                })
+                .addActivity(plusOne, ctx -> ctx.getInput(int.class) + 1)
+                .buildAndStart();
+
+        DurableTaskClient client = this.createClientBuilder().build();
+        try (worker; client) {
+            Instant from = Instant.now().minus(Duration.ofMinutes(1));
+
+            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName, 0);
+            OrchestrationMetadata metadata = client.waitForInstanceCompletion(instanceId, defaultTimeout, false);
+            assertEquals(OrchestrationRuntimeStatus.COMPLETED, metadata.getRuntimeStatus());
+
+            ListInstanceIdsResult result = client.listInstanceIds(new ListInstanceIdsQuery()
+                    .setCompletedTimeFrom(from)
+                    .setRuntimeStatusList(Collections.singletonList(OrchestrationRuntimeStatus.COMPLETED))
+                    .setPageSize(100));
+
+            assertNotNull(result);
+            assertNotNull(result.getInstanceIds());
+            assertTrue(result.getInstanceIds().contains(instanceId),
+                    "Expected listInstanceIds to include the completed instance " + instanceId);
+        }
+    }
+
+    @Test
+    void getOrchestrationHistoryReturnsDomainEvents() throws TimeoutException {
+        final String orchestratorName = "StreamHistoryExport";
+        final String plusOne = "PlusOne";
+
+        DurableTaskGrpcWorker worker = this.createWorkerBuilder()
+                .addOrchestrator(orchestratorName, ctx -> {
+                    int value = ctx.getInput(int.class);
+                    value = ctx.callActivity(plusOne, value, int.class).await();
+                    ctx.complete(value);
+                })
+                .addActivity(plusOne, ctx -> ctx.getInput(int.class) + 1)
+                .buildAndStart();
+
+        DurableTaskClient client = this.createClientBuilder().build();
+        try (worker; client) {
+            String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName, 0);
+            OrchestrationMetadata metadata = client.waitForInstanceCompletion(instanceId, defaultTimeout, false);
+            assertEquals(OrchestrationRuntimeStatus.COMPLETED, metadata.getRuntimeStatus());
+
+            List<HistoryEvent> history = client.getOrchestrationHistory(instanceId);
+
+            assertNotNull(history);
+            assertFalse(history.isEmpty(), "Expected a completed instance to have history events");
+            // A completed orchestration's history begins with an ExecutionStartedEvent.
+            assertTrue(history.stream().anyMatch(e -> e instanceof ExecutionStartedEvent),
+                    "Expected history to contain an ExecutionStartedEvent");
+            // And it contains a successful activity completion.
+            assertTrue(history.stream().anyMatch(e -> e instanceof TaskCompletedEvent),
+                    "Expected history to contain a TaskCompletedEvent");
         }
     }
 

--- a/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
+++ b/client/src/test/java/com/microsoft/durabletask/IntegrationTests.java
@@ -1320,14 +1320,12 @@ public class IntegrationTests extends IntegrationTestBase {
 
         DurableTaskClient client = this.createClientBuilder().build();
         try (worker; client) {
-            Instant from = Instant.now().minus(Duration.ofMinutes(1));
-
             String instanceId = client.scheduleNewOrchestrationInstance(orchestratorName, 0);
             OrchestrationMetadata metadata = client.waitForInstanceCompletion(instanceId, defaultTimeout, false);
             assertEquals(OrchestrationRuntimeStatus.COMPLETED, metadata.getRuntimeStatus());
 
             ListInstanceIdsResult result = client.listInstanceIds(new ListInstanceIdsQuery()
-                    .setCompletedTimeFrom(from)
+                    .setCompletedTimeFrom(metadata.getCreatedAt())
                     .setRuntimeStatusList(Collections.singletonList(OrchestrationRuntimeStatus.COMPLETED))
                     .setPageSize(100));
 

--- a/client/src/test/java/com/microsoft/durabletask/ListInstanceIdsQueryTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/ListInstanceIdsQueryTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -40,5 +41,18 @@ public class ListInstanceIdsQueryTest {
         source.add(OrchestrationRuntimeStatus.FAILED);
 
         assertEquals(Arrays.asList(OrchestrationRuntimeStatus.COMPLETED), query.getRuntimeStatusList());
+    }
+
+    @Test
+    void setPageSize_positiveValue_updatesPageSize() {
+        ListInstanceIdsQuery query = new ListInstanceIdsQuery().setPageSize(25);
+
+        assertEquals(25, query.getPageSize());
+    }
+
+    @Test
+    void setPageSize_zeroOrNegative_throws() {
+        assertThrows(IllegalArgumentException.class, () -> new ListInstanceIdsQuery().setPageSize(0));
+        assertThrows(IllegalArgumentException.class, () -> new ListInstanceIdsQuery().setPageSize(-1));
     }
 }

--- a/client/src/test/java/com/microsoft/durabletask/ListInstanceIdsQueryTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/ListInstanceIdsQueryTest.java
@@ -4,6 +4,7 @@ package com.microsoft.durabletask;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +42,30 @@ public class ListInstanceIdsQueryTest {
         source.add(OrchestrationRuntimeStatus.FAILED);
 
         assertEquals(Arrays.asList(OrchestrationRuntimeStatus.COMPLETED), query.getRuntimeStatusList());
+    }
+
+    @Test
+    void getRuntimeStatusList_returnsUnmodifiableView() {
+        ListInstanceIdsQuery query = new ListInstanceIdsQuery()
+                .setRuntimeStatusList(Arrays.asList(OrchestrationRuntimeStatus.COMPLETED));
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> query.getRuntimeStatusList().add(OrchestrationRuntimeStatus.FAILED));
+    }
+
+    @Test
+    void getters_returnConfiguredValues() {
+        Instant completedTimeFrom = Instant.parse("2026-01-01T00:00:00Z");
+        Instant completedTimeTo = Instant.parse("2026-01-02T00:00:00Z");
+        ListInstanceIdsQuery query = new ListInstanceIdsQuery()
+                .setCompletedTimeFrom(completedTimeFrom)
+                .setCompletedTimeTo(completedTimeTo)
+                .setContinuationToken("next-page");
+
+        assertEquals(completedTimeFrom, query.getCompletedTimeFrom());
+        assertEquals(completedTimeTo, query.getCompletedTimeTo());
+        assertEquals("next-page", query.getContinuationToken());
     }
 
     @Test

--- a/client/src/test/java/com/microsoft/durabletask/ListInstanceIdsQueryTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/ListInstanceIdsQueryTest.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ListInstanceIdsQuery}.
+ */
+public class ListInstanceIdsQueryTest {
+
+    @Test
+    void getRuntimeStatusList_default_isEmptyNonNull() {
+        ListInstanceIdsQuery query = new ListInstanceIdsQuery();
+        assertNotNull(query.getRuntimeStatusList());
+        assertTrue(query.getRuntimeStatusList().isEmpty());
+    }
+
+    @Test
+    void setRuntimeStatusList_null_normalizesToEmptyList() {
+        ListInstanceIdsQuery query = new ListInstanceIdsQuery().setRuntimeStatusList(null);
+        assertNotNull(query.getRuntimeStatusList());
+        assertTrue(query.getRuntimeStatusList().isEmpty());
+    }
+
+    @Test
+    void setRuntimeStatusList_copiesInput_soExternalMutationDoesNotAffectQuery() {
+        List<OrchestrationRuntimeStatus> source = new ArrayList<>();
+        source.add(OrchestrationRuntimeStatus.COMPLETED);
+
+        ListInstanceIdsQuery query = new ListInstanceIdsQuery().setRuntimeStatusList(source);
+        source.add(OrchestrationRuntimeStatus.FAILED);
+
+        assertEquals(Arrays.asList(OrchestrationRuntimeStatus.COMPLETED), query.getRuntimeStatusList());
+    }
+}

--- a/client/src/test/java/com/microsoft/durabletask/history/OrchestrationStateTest.java
+++ b/client/src/test/java/com/microsoft/durabletask/history/OrchestrationStateTest.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.microsoft.durabletask.history;
+
+import com.microsoft.durabletask.OrchestrationRuntimeStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link OrchestrationState}.
+ */
+public class OrchestrationStateTest {
+
+    @Test
+    void nullTagsNormalizeToEmptyUnmodifiableMap() {
+        OrchestrationState state = new OrchestrationState(
+                "instance-id",
+                "orchestration-name",
+                null,
+                OrchestrationRuntimeStatus.COMPLETED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        assertNotNull(state.getTags());
+        assertTrue(state.getTags().isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> state.getTags().put("env", "prod"));
+    }
+}


### PR DESCRIPTION
### Issue describing the changes in this PR

Adds client APIs to enumerate orchestration instances and read a completed instance's
history, plus a public history-event model.

#### Changes
- **`DurableTaskClient.listInstanceIds(ListInstanceIdsQuery)`** → `ListInstanceIdsResult` — page terminal/instance IDs by filter (completion window, statuses, continuation token).
- **`DurableTaskClient.getOrchestrationHistory(String instanceId)`** → `List<HistoryEvent>` — retrieve an instance's full ordered history.
- **New public model** `com.microsoft.durabletask.history` — `HistoryEvent` plus per-type subclasses (`ExecutionStarted/Completed`, `TaskScheduled/Completed/Failed`, `Timer*`, `SubOrchestration*`, `EntityOperation*`/`EntityLock*`, `EventSent/Raised`, `Generic`, `HistoryState`, …).
- Backed by the `ListInstanceIds` and `StreamInstanceHistory` gRPC operations (managed DTS; sidecar/emulator ≥ v0.4.22).

##### Notes
- Foundation for a follow-up durable history-export feature (stacked PR).

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)