### PR TITLE
Resolve Gradle dependencies through the azfunc Azure Artifacts feed

### DIFF
--- a/azdevops-pipeline/build-release-artifacts.yml
+++ b/azdevops-pipeline/build-release-artifacts.yml
@@ -24,6 +24,7 @@ steps:
     jdkArchitectureOption: 'x64'
     publishJUnitResults: false
     tasks: clean assemble
+    options: '--init-script init.gradle'
   displayName: Assemble durabletask-client and durabletask-azure-functions
 
 # the secring.gpg file is required to sign the artifacts, it's generated from GnuPG, and it's stored in the library of the durabletaskframework ADO
@@ -42,7 +43,7 @@ steps:
     jdkVersionOption: '$(jdkVersion)'
     jdkArchitectureOption: 'x64'
     tasks: publish
-    options: '-Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
+    options: '--init-script init.gradle -Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
   displayName: Publish durabletask-client and durabletask-azure-functions
     
 - task: CopyFiles@2

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -24,7 +24,7 @@ jobs:
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
             tasks: clean assemble
-            options: '--init-script init.gradle --info'
+            options: '--init-script init.gradle'
           displayName: Assemble durabletask-client and durabletask-azure-functions and durabletask-azuremanaged
 
         # the secring.gpg file is required to sign the artifacts, it's generated from GnuPG, and it's stored in the library of the durabletaskframework ADO
@@ -43,7 +43,7 @@ jobs:
             jdkVersionOption: 1.11
             jdkArchitectureOption: 'x64'
             tasks: publish
-            options: '--init-script init.gradle --info -Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
+            options: '--init-script init.gradle -Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
           displayName: Publish durabletask-client and durabletask-azure-functions and durabletask-azuremanaged
 
         - task: CopyFiles@2

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -11,6 +11,13 @@ jobs:
       steps:
         - checkout: self
 
+        # Authenticate to the azfunc upstream-public Azure Artifacts feed using the build identity
+        # (no stored secret). Writes credentials to ~/.m2/settings.xml, which settings.gradle reads.
+        - task: MavenAuthenticate@0
+          displayName: 'Authenticate to Azure Artifacts feed'
+          inputs:
+            artifactsFeeds: upstream-public
+
         - task: Gradle@3
           inputs:
             # Specifies the working directory to run the Gradle build. The task uses the repository root directory if the working directory is not specified.

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -24,7 +24,7 @@ jobs:
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
             tasks: clean assemble
-            options: '--init-script init.gradle'
+            options: '--init-script init.gradle --info'
           displayName: Assemble durabletask-client and durabletask-azure-functions and durabletask-azuremanaged
 
         # the secring.gpg file is required to sign the artifacts, it's generated from GnuPG, and it's stored in the library of the durabletaskframework ADO
@@ -43,7 +43,7 @@ jobs:
             jdkVersionOption: 1.11
             jdkArchitectureOption: 'x64'
             tasks: publish
-            options: '--init-script init.gradle -Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
+            options: '--init-script init.gradle --info -Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
           displayName: Publish durabletask-client and durabletask-azure-functions and durabletask-azuremanaged
 
         - task: CopyFiles@2

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -11,13 +11,6 @@ jobs:
       steps:
         - checkout: self
 
-        # Authenticate to the azfunc upstream-public Azure Artifacts feed using the build identity
-        # (no stored secret). Writes credentials to ~/.m2/settings.xml, which settings.gradle reads.
-        - task: MavenAuthenticate@0
-          displayName: 'Authenticate to Azure Artifacts feed'
-          inputs:
-            artifactsFeeds: upstream-public
-
         - task: Gradle@3
           inputs:
             # Specifies the working directory to run the Gradle build. The task uses the repository root directory if the working directory is not specified.
@@ -31,6 +24,7 @@ jobs:
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
             tasks: clean assemble
+            options: '--init-script init.gradle'
           displayName: Assemble durabletask-client and durabletask-azure-functions and durabletask-azuremanaged
 
         # the secring.gpg file is required to sign the artifacts, it's generated from GnuPG, and it's stored in the library of the durabletaskframework ADO
@@ -49,7 +43,7 @@ jobs:
             jdkVersionOption: 1.11
             jdkArchitectureOption: 'x64'
             tasks: publish
-            options: '-Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
+            options: '--init-script init.gradle -Psigning.keyId=$(gpgSignKey) -Psigning.password=$(gpgSignPassword) -Psigning.secretKeyRingFile=$(gpgSecretFile.secureFilePath)'
           displayName: Publish durabletask-client and durabletask-azure-functions and durabletask-azuremanaged
 
         - task: CopyFiles@2

--- a/init.gradle
+++ b/init.gradle
@@ -1,0 +1,22 @@
+allprojects {
+    def azfuncFeedToken = System.getenv('AZURE_ARTIFACTS_ENV_ACCESS_TOKEN') ?: findProperty('vstsMavenAccessToken')
+    repositories {
+        all { ArtifactRepository repo ->
+            if (repo instanceof MavenArtifactRepository &&
+                (repo.url.toString().contains('.maven.org') ||
+                 repo.url.toString().contains('maven.apache.org') ||
+                 repo.url.toString().contains('oss.sonatype.org'))) {
+                remove repo
+            }
+        }
+        maven {
+            url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
+            if (azfuncFeedToken) {
+                credentials {
+                    username 'Azure DevOps Services'
+                    password azfuncFeedToken
+                }
+            }
+        }
+    }
+}

--- a/init.gradle
+++ b/init.gradle
@@ -1,13 +1,6 @@
 allprojects {
     def azfuncFeedToken = System.getenv('AZURE_ARTIFACTS_ENV_ACCESS_TOKEN') ?: findProperty('vstsMavenAccessToken')
     repositories {
-        all { ArtifactRepository repo ->
-            if (repo instanceof MavenArtifactRepository &&
-                (repo.url.toString().contains('.maven.org') ||
-                 repo.url.toString().contains('maven.apache.org'))) {
-                remove repo
-            }
-        }
         maven {
             url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
             if (azfuncFeedToken) {
@@ -17,5 +10,15 @@ allprojects {
                 }
             }
         }
+    }
+    // Strip public Maven Central repos after all build scripts have declared them.
+    // Snapshot the list first — removing while iterating repositories.all {} silently skips entries.
+    afterEvaluate { proj ->
+        def publicMavenRepos = proj.repositories.findAll { repo ->
+            repo instanceof MavenArtifactRepository &&
+            (repo.url.toString().contains('.maven.org') ||
+             repo.url.toString().contains('maven.apache.org'))
+        }
+        publicMavenRepos.each { proj.repositories.remove(it) }
     }
 }

--- a/init.gradle
+++ b/init.gradle
@@ -4,8 +4,7 @@ allprojects {
         all { ArtifactRepository repo ->
             if (repo instanceof MavenArtifactRepository &&
                 (repo.url.toString().contains('.maven.org') ||
-                 repo.url.toString().contains('maven.apache.org') ||
-                 repo.url.toString().contains('oss.sonatype.org'))) {
+                 repo.url.toString().contains('maven.apache.org'))) {
                 remove repo
             }
         }

--- a/init.gradle
+++ b/init.gradle
@@ -1,8 +1,9 @@
 allprojects {
+    def azfuncFeedUrl = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
     def azfuncFeedToken = System.getenv('AZURE_ARTIFACTS_ENV_ACCESS_TOKEN') ?: findProperty('vstsMavenAccessToken')
     repositories {
         maven {
-            url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
+            url azfuncFeedUrl
             if (azfuncFeedToken) {
                 credentials {
                     username 'Azure DevOps Services'
@@ -11,14 +12,15 @@ allprojects {
             }
         }
     }
-    // Strip public Maven Central repos after all build scripts have declared them.
-    // Snapshot the list first — removing while iterating repositories.all {} silently skips entries.
+    // Keep only the Azure Artifacts feed (and MavenLocal); remove every other Maven repository so no
+    // public repository can bypass the feed.
     afterEvaluate { proj ->
-        def publicMavenRepos = proj.repositories.findAll { repo ->
+        def isNonFeedMaven = { repo ->
             repo instanceof MavenArtifactRepository &&
-            (repo.url.toString().contains('.maven.org') ||
-             repo.url.toString().contains('maven.apache.org'))
+            repo.name != 'MavenLocal' &&
+            !repo.url.toString().startsWith(azfuncFeedUrl)
         }
-        publicMavenRepos.each { proj.repositories.remove(it) }
+        proj.repositories.findAll(isNonFeedMaven).each { proj.repositories.remove(it) }
+        proj.buildscript.repositories.findAll(isNonFeedMaven).each { proj.buildscript.repositories.remove(it) }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,17 @@
 pluginManagement {
-    // Resolve plugins through the Azure Artifacts feed only.
+    // Resolve plugins from the Azure Artifacts feed when its token is available; otherwise the public portal.
     def azfuncFeedToken = System.getenv('AZURE_ARTIFACTS_ENV_ACCESS_TOKEN') ?: providers.gradleProperty('vstsMavenAccessToken').orNull
     repositories {
-        maven {
-            url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
-            if (azfuncFeedToken) {
+        if (azfuncFeedToken) {
+            maven {
+                url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
                 credentials {
                     username 'Azure DevOps Services'
                     password azfuncFeedToken
                 }
             }
+        } else {
+            gradlePluginPortal()
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,44 @@
 rootProject.name = 'durabletask-java'
 
+// Resolve all dependencies through the azfunc upstream-public Azure Artifacts feed instead of
+// Maven Central. PREFER_SETTINGS makes per-project mavenCentral()/oss.sonatype.org repositories
+// inert so the build never reaches repo.maven.apache.org.
+//
+// CI auth: MavenAuthenticate@0 writes feed credentials to ~/.m2/settings.xml using the build
+// identity (no stored secret). Gradle doesn't read that file, so extract the token here. When the
+// file is absent (external clones / local dev), the feed is read anonymously.
+def azfuncFeedUser = null
+def azfuncFeedToken = null
+def m2Settings = new File(System.getProperty('user.home'), '.m2/settings.xml')
+if (m2Settings.exists()) {
+    try {
+        // MavenAuthenticate@0 writes a <server> whose id is the feed name (upstream-public).
+        def server = new XmlSlurper().parse(m2Settings).servers.server.find { it.id.text() == 'upstream-public' }
+        if (server) {
+            azfuncFeedUser = server.username.text()
+            azfuncFeedToken = server.password.text()
+        }
+    } catch (Exception ignored) {
+        // Malformed/unreadable settings.xml: fall back to anonymous reads.
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        maven {
+            url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
+            if (azfuncFeedToken) {
+                credentials {
+                    username azfuncFeedUser ?: 'AzureDevOps'
+                    password azfuncFeedToken
+                }
+                authentication { basic(BasicAuthentication) }
+            }
+        }
+    }
+}
+
 include ":client"
 include ":azurefunctions"
 include ":azuremanaged"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
-    // Feed-first so plugin-classpath artifacts (and their Gradle Module Metadata probes)
-    // resolve from the Azure Artifacts feed instead of being redirected to Maven Central.
+    // Resolve plugins through the Azure Artifacts feed only.
     def azfuncFeedToken = System.getenv('AZURE_ARTIFACTS_ENV_ACCESS_TOKEN') ?: providers.gradleProperty('vstsMavenAccessToken').orNull
     repositories {
         maven {
@@ -12,7 +11,6 @@ pluginManagement {
                 }
             }
         }
-        gradlePluginPortal()
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,44 +1,5 @@
 rootProject.name = 'durabletask-java'
 
-// Resolve all dependencies through the azfunc upstream-public Azure Artifacts feed instead of
-// Maven Central. PREFER_SETTINGS makes per-project mavenCentral()/oss.sonatype.org repositories
-// inert so the build never reaches repo.maven.apache.org.
-//
-// CI auth: MavenAuthenticate@0 writes feed credentials to ~/.m2/settings.xml using the build
-// identity (no stored secret). Gradle doesn't read that file, so extract the token here. When the
-// file is absent (external clones / local dev), the feed is read anonymously.
-def azfuncFeedUser = null
-def azfuncFeedToken = null
-def m2Settings = new File(System.getProperty('user.home'), '.m2/settings.xml')
-if (m2Settings.exists()) {
-    try {
-        // MavenAuthenticate@0 writes a <server> whose id is the feed name (upstream-public).
-        def server = new XmlSlurper().parse(m2Settings).servers.server.find { it.id.text() == 'upstream-public' }
-        if (server) {
-            azfuncFeedUser = server.username.text()
-            azfuncFeedToken = server.password.text()
-        }
-    } catch (Exception ignored) {
-        // Malformed/unreadable settings.xml: fall back to anonymous reads.
-    }
-}
-
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-    repositories {
-        maven {
-            url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
-            if (azfuncFeedToken) {
-                credentials {
-                    username azfuncFeedUser ?: 'AzureDevOps'
-                    password azfuncFeedToken
-                }
-                authentication { basic(BasicAuthentication) }
-            }
-        }
-    }
-}
-
 include ":client"
 include ":azurefunctions"
 include ":azuremanaged"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,21 @@
+pluginManagement {
+    // Feed-first so plugin-classpath artifacts (and their Gradle Module Metadata probes)
+    // resolve from the Azure Artifacts feed instead of being redirected to Maven Central.
+    def azfuncFeedToken = System.getenv('AZURE_ARTIFACTS_ENV_ACCESS_TOKEN') ?: providers.gradleProperty('vstsMavenAccessToken').orNull
+    repositories {
+        maven {
+            url 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
+            if (azfuncFeedToken) {
+                credentials {
+                    username 'Azure DevOps Services'
+                    password azfuncFeedToken
+                }
+            }
+        }
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'durabletask-java'
 
 include ":client"


### PR DESCRIPTION
### Issue describing the changes in this PR
Configures the CI build to resolve Maven-format dependencies from the `upstream-public`
Azure Artifacts feed instead of public Maven Central

**Changes**
- Adds `init.gradle` (applied in CI via `--init-script`): for every project it removes any
  Maven Central repository and replaces it with
  `https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1`, so the build
  no longer reaches `repo.maven.apache.org`. Feed credentials come from the build identity via
  `AZURE_ARTIFACTS_ENV_ACCESS_TOKEN` (no stored secret). When no token is present (external clones /
  local dev), the feed is read anonymously, so external contributors are unaffected.
- `eng/templates/build.yml`: both `Gradle@3` tasks now pass `--init-script init.gradle`.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
* [ ] I have added all required tests (Unit tests, E2E tests)